### PR TITLE
Add uni-app miniapp frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# pet
-# pet
+# Pet Feeding Service
+
+This repository contains the backend and frontend code for the pet feeding mini-program project.
+
+## Structure
+
+- `backend/` - NestJS backend service
+- `frontend/miniapp/` - Uni-app based WeChat mini-program
+
+The project currently does **not** include a web-based admin console. Consider generating or implementing one separately if needed.

--- a/frontend/miniapp/App.vue
+++ b/frontend/miniapp/App.vue
@@ -1,0 +1,14 @@
+<template>
+  <view><slot /></view>
+</template>
+
+<script>
+export default {
+  onLaunch() {},
+  onShow() {},
+  onHide() {}
+}
+</script>
+
+<style src="./static/colorui/main.css"></style>
+<style src="./static/ThorUI/thorui.css"></style>

--- a/frontend/miniapp/main.js
+++ b/frontend/miniapp/main.js
@@ -1,0 +1,13 @@
+import Vue from 'vue'
+import App from './App'
+import store from './store'
+
+Vue.config.productionTip = false
+
+App.mpType = 'app'
+
+const app = new Vue({
+  store,
+  ...App
+})
+app.$mount()

--- a/frontend/miniapp/manifest.json
+++ b/frontend/miniapp/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "pet-feeder-miniapp",
+  "appid": "__UNI__PETFEEDER",
+  "description": "Pet feeder mini program",
+  "versionName": "1.0.0",
+  "versionCode": "100",
+  "platforms": {
+    "mp-weixin": {}
+  }
+}

--- a/frontend/miniapp/pages.json
+++ b/frontend/miniapp/pages.json
@@ -1,0 +1,17 @@
+{
+  "pages": [
+    {"path": "pages/login/index", "style": {"navigationBarTitleText": "登录"}},
+    {"path": "pages/pets/list", "style": {"navigationBarTitleText": "我的宠物"}},
+    {"path": "pages/pets/edit", "style": {"navigationBarTitleText": "编辑宠物"}},
+    {"path": "pages/appointment/book", "style": {"navigationBarTitleText": "预约服务"}},
+    {"path": "pages/orders/list", "style": {"navigationBarTitleText": "订单列表"}},
+    {"path": "pages/orders/detail", "style": {"navigationBarTitleText": "订单详情"}},
+    {"path": "pages/user/profile", "style": {"navigationBarTitleText": "个人中心"}},
+    {"path": "pages/pay/result", "style": {"navigationBarTitleText": "支付结果"}}
+  ],
+  "globalStyle": {
+    "navigationBarTitleText": "Pet Feeder",
+    "navigationBarBackgroundColor": "#ffffff",
+    "backgroundColor": "#f8f8f8"
+  }
+}

--- a/frontend/miniapp/pages/appointment/book.vue
+++ b/frontend/miniapp/pages/appointment/book.vue
@@ -1,0 +1,45 @@
+<template>
+  <view class="container">
+    <picker mode="date" @change="onDateChange">
+      <view>{{ date || '选择日期' }}</view>
+    </picker>
+    <input v-model="time" placeholder="服务时间" />
+    <input v-model="address" placeholder="服务地址" />
+    <textarea v-model="remark" placeholder="备注"></textarea>
+    <button type="primary" @click="submit">预约</button>
+  </view>
+</template>
+
+<script>
+import { request } from '@/utils/request'
+
+export default {
+  data() {
+    return {
+      date: '',
+      time: '',
+      address: '',
+      remark: ''
+    }
+  },
+  methods: {
+    onDateChange(e) {
+      this.date = e.detail.value
+    },
+    submit() {
+      request({
+        url: '/orders',
+        method: 'POST',
+        data: {
+          date: this.date,
+          time: this.time,
+          address: this.address,
+          remark: this.remark
+        }
+      }).then(res => {
+        uni.redirectTo({ url: '/pages/pay/result?id=' + res.id })
+      })
+    }
+  }
+}
+</script>

--- a/frontend/miniapp/pages/login/index.vue
+++ b/frontend/miniapp/pages/login/index.vue
@@ -1,0 +1,28 @@
+<template>
+  <view class="container">
+    <button type="primary" @click="doLogin">微信登录</button>
+  </view>
+</template>
+
+<script>
+import { login } from '@/utils/auth'
+
+export default {
+  methods: {
+    async doLogin() {
+      try {
+        await login()
+        uni.reLaunch({ url: '/pages/user/profile' })
+      } catch (e) {
+        uni.showToast({ title: '登录失败', icon: 'none' })
+      }
+    }
+  }
+}
+</script>
+
+<style>
+.container {
+  padding: 30rpx;
+}
+</style>

--- a/frontend/miniapp/pages/orders/detail.vue
+++ b/frontend/miniapp/pages/orders/detail.vue
@@ -1,0 +1,38 @@
+<template>
+  <view>
+    <view>订单号: {{ detail.id }}</view>
+    <view>状态: {{ detail.status }}</view>
+    <button v-if="detail.status === 'pending'" type="primary" @click="pay">支付</button>
+  </view>
+</template>
+
+<script>
+import { request } from '@/utils/request'
+
+export default {
+  data() {
+    return { detail: {} }
+  },
+  onLoad(options) {
+    request({ url: '/orders/' + options.id }).then(res => {
+      this.detail = res
+    })
+  },
+  methods: {
+    pay() {
+      request({ url: `/orders/${this.detail.id}/pay` }).then(payData => {
+        wx.requestPayment({
+          ...payData,
+          success: () => {
+            uni.showToast({ title: '支付成功' })
+            this.detail.status = 'paid'
+          },
+          fail: () => {
+            uni.showToast({ title: '支付失败', icon: 'none' })
+          }
+        })
+      })
+    }
+  }
+}
+</script>

--- a/frontend/miniapp/pages/orders/list.vue
+++ b/frontend/miniapp/pages/orders/list.vue
@@ -1,0 +1,27 @@
+<template>
+  <view>
+    <view v-for="item in orders" :key="item.id" @click="goDetail(item.id)">
+      <text>{{ item.date }} {{ item.status }}</text>
+    </view>
+  </view>
+</template>
+
+<script>
+import { request } from '@/utils/request'
+
+export default {
+  data() {
+    return { orders: [] }
+  },
+  onShow() {
+    request({ url: '/orders' }).then(res => {
+      this.orders = res
+    })
+  },
+  methods: {
+    goDetail(id) {
+      uni.navigateTo({ url: '/pages/orders/detail?id=' + id })
+    }
+  }
+}
+</script>

--- a/frontend/miniapp/pages/pay/result.vue
+++ b/frontend/miniapp/pages/pay/result.vue
@@ -1,0 +1,19 @@
+<template>
+  <view>
+    <view>支付结果: {{ status }}</view>
+    <button @click="goOrders">查看订单</button>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return { status: '成功' }
+  },
+  methods: {
+    goOrders() {
+      uni.redirectTo({ url: '/pages/orders/list' })
+    }
+  }
+}
+</script>

--- a/frontend/miniapp/pages/pets/edit.vue
+++ b/frontend/miniapp/pages/pets/edit.vue
@@ -1,0 +1,66 @@
+<template>
+  <view class="container">
+    <view class="form-item">
+      <input v-model="form.name" placeholder="名字" />
+    </view>
+    <view class="form-item">
+      <input v-model="form.type" placeholder="种类" />
+    </view>
+    <view class="form-item">
+      <picker :range="genderOptions" @change="changeGender">
+        <view>{{ genderText }}</view>
+      </picker>
+    </view>
+    <view class="form-item">
+      <input v-model="form.age" placeholder="年龄" />
+    </view>
+    <button type="primary" @click="submit">保存</button>
+  </view>
+</template>
+
+<script>
+import { request } from '@/utils/request'
+
+export default {
+  data() {
+    return {
+      form: {
+        id: '',
+        name: '',
+        type: '',
+        gender: '',
+        age: ''
+      },
+      genderOptions: ['公', '母']
+    }
+  },
+  onLoad(options) {
+    if (options.id) {
+      this.form.id = options.id
+      this.loadPet()
+    }
+  },
+  computed: {
+    genderText() {
+      return this.form.gender !== '' ? this.genderOptions[this.form.gender] : '选择性别'
+    }
+  },
+  methods: {
+    changeGender(e) {
+      this.form.gender = e.detail.value
+    },
+    loadPet() {
+      request({ url: `/pets/${this.form.id}` }).then(res => {
+        this.form = res
+      })
+    },
+    submit() {
+      const method = this.form.id ? 'PUT' : 'POST'
+      const url = this.form.id ? `/pets/${this.form.id}` : '/pets'
+      request({ url, method, data: this.form }).then(() => {
+        uni.navigateBack()
+      })
+    }
+  }
+}
+</script>

--- a/frontend/miniapp/pages/pets/list.vue
+++ b/frontend/miniapp/pages/pets/list.vue
@@ -1,0 +1,33 @@
+<template>
+  <view class="container">
+    <view v-for="pet in pets" :key="pet.id" class="pet-item">
+      <text>{{ pet.name }}</text>
+    </view>
+    <button type="primary" @click="goAdd">添加宠物</button>
+  </view>
+</template>
+
+<script>
+import { request } from '@/utils/request'
+
+export default {
+  data() {
+    return {
+      pets: []
+    }
+  },
+  onShow() {
+    this.fetchPets()
+  },
+  methods: {
+    fetchPets() {
+      request({ url: '/pets' }).then(res => {
+        this.pets = res
+      })
+    },
+    goAdd() {
+      uni.navigateTo({ url: '/pages/pets/edit' })
+    }
+  }
+}
+</script>

--- a/frontend/miniapp/pages/user/profile.vue
+++ b/frontend/miniapp/pages/user/profile.vue
@@ -1,0 +1,25 @@
+<template>
+  <view>
+    <view>昵称：{{ user && user.nickname }}</view>
+    <button @click="logout">退出登录</button>
+  </view>
+</template>
+
+<script>
+import store from '@/store'
+
+export default {
+  computed: {
+    user() {
+      return store.state.user
+    }
+  },
+  methods: {
+    logout() {
+      store.commit('setToken', '')
+      store.commit('setUser', null)
+      uni.reLaunch({ url: '/pages/login/index' })
+    }
+  }
+}
+</script>

--- a/frontend/miniapp/static/ThorUI/thorui.css
+++ b/frontend/miniapp/static/ThorUI/thorui.css
@@ -1,0 +1,1 @@
+/* ThorUI styles placeholder */

--- a/frontend/miniapp/static/colorui/main.css
+++ b/frontend/miniapp/static/colorui/main.css
@@ -1,0 +1,1 @@
+/* ColorUI styles placeholder */

--- a/frontend/miniapp/store/index.js
+++ b/frontend/miniapp/store/index.js
@@ -1,0 +1,21 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+Vue.use(Vuex)
+
+const store = new Vuex.Store({
+  state: {
+    token: '',
+    user: null
+  },
+  mutations: {
+    setToken(state, token) {
+      state.token = token
+    },
+    setUser(state, user) {
+      state.user = user
+    }
+  }
+})
+
+export default store

--- a/frontend/miniapp/utils/auth.js
+++ b/frontend/miniapp/utils/auth.js
@@ -1,0 +1,22 @@
+import { request } from './request'
+import store from '../store'
+
+export function login() {
+  return new Promise((resolve, reject) => {
+    uni.login({
+      success(res) {
+        request({
+          url: '/auth/login',
+          method: 'POST',
+          data: { code: res.code }
+        })
+          .then(data => {
+            store.commit('setToken', data.access_token)
+            resolve(data)
+          })
+          .catch(reject)
+      },
+      fail: reject
+    })
+  })
+}

--- a/frontend/miniapp/utils/request.js
+++ b/frontend/miniapp/utils/request.js
@@ -1,0 +1,14 @@
+const baseUrl = 'http://localhost:3000'
+
+export function request({ url, method = 'GET', data = {}, header = {} }) {
+  return new Promise((resolve, reject) => {
+    uni.request({
+      url: baseUrl + url,
+      method,
+      data,
+      header,
+      success: res => resolve(res.data),
+      fail: reject
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- setup `frontend/miniapp` directory for a uni-app based WeChat mini program
- add login, pets, appointment, orders, pay and user pages
- integrate placeholder ColorUI and ThorUI styles
- include simple Vuex store and request utilities
- document project layout in README

## Testing
- `npm install` in `backend/pet-feeder-backend`
- `npm test` in `backend/pet-feeder-backend`

------
https://chatgpt.com/codex/tasks/task_e_68762115630c8320abf91247fae7e850