### PR TITLE
Implement feeder service order module and frontend skeleton

### DIFF
--- a/backend/pet-feeder-backend/src/app.module.ts
+++ b/backend/pet-feeder-backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { PetsModule } from './pets/pets.module';
 import { OrdersModule } from './orders/orders.module';
 import { FeedersModule } from './feeders/feeders.module';
 import { AuthModule } from './auth/auth.module';
+import { ServiceOrdersModule } from './service-orders/service-orders.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { AuthModule } from './auth/auth.module';
     PetsModule,
     OrdersModule,
     FeedersModule,
+    ServiceOrdersModule,
     AuthModule,
   ],
   controllers: [AppController],

--- a/backend/pet-feeder-backend/src/feeders/dto/create-feeder.dto.ts
+++ b/backend/pet-feeder-backend/src/feeders/dto/create-feeder.dto.ts
@@ -1,5 +1,8 @@
 export class CreateFeederDto {
+  userId: number;
   name: string;
   phone: string;
+  idCard: string;
+  avatar?: string;
   rating?: number;
 }

--- a/backend/pet-feeder-backend/src/feeders/entities/feeder.entity.ts
+++ b/backend/pet-feeder-backend/src/feeders/entities/feeder.entity.ts
@@ -1,17 +1,43 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  CreateDateColumn,
+} from 'typeorm';
 import { Order } from '../../orders/entities/order.entity';
 import { Pet } from '../../pets/entities/pet.entity';
+import { User } from '../../users/entities/user.entity';
 
 @Entity('feeders')
 export class Feeder {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @ManyToOne(() => User)
+  user: User;
+
   @Column({ length: 100 })
   name: string;
 
   @Column({ length: 20 })
   phone: string;
+
+  @Column({ length: 18 })
+  idCard: string;
+
+  @Column({ length: 255, nullable: true })
+  avatar?: string;
+
+  @Column('tinyint', { default: 0 })
+  status: number;
+
+  @Column('tinyint', { default: 0 })
+  isBlacklist: number;
+
+  @CreateDateColumn()
+  createTime: Date;
 
   @Column('decimal', { precision: 3, scale: 2, default: 0 })
   rating: number;

--- a/backend/pet-feeder-backend/src/feeders/feeders.controller.ts
+++ b/backend/pet-feeder-backend/src/feeders/feeders.controller.ts
@@ -27,6 +27,11 @@ export class FeedersController {
     return this.feedersService.update(+id, updateFeederDto);
   }
 
+  @Patch(':id/status/:status')
+  updateStatus(@Param('id') id: string, @Param('status') status: string) {
+    return this.feedersService.updateStatus(+id, +status);
+  }
+
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.feedersService.remove(+id);

--- a/backend/pet-feeder-backend/src/feeders/feeders.service.ts
+++ b/backend/pet-feeder-backend/src/feeders/feeders.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { CreateFeederDto } from './dto/create-feeder.dto';
 import { UpdateFeederDto } from './dto/update-feeder.dto';
 import { Feeder } from './entities/feeder.entity';
+import { User } from '../users/entities/user.entity';
 
 @Injectable()
 export class FeedersService {
@@ -13,7 +14,10 @@ export class FeedersService {
   ) {}
 
   create(createFeederDto: CreateFeederDto) {
-    const feeder = this.feedersRepository.create(createFeederDto);
+    const feeder = this.feedersRepository.create({
+      ...createFeederDto,
+      user: { id: createFeederDto.userId } as User,
+    });
     return this.feedersRepository.save(feeder);
   }
 
@@ -27,6 +31,10 @@ export class FeedersService {
 
   update(id: number, updateFeederDto: UpdateFeederDto) {
     return this.feedersRepository.update(id, updateFeederDto);
+  }
+
+  updateStatus(id: number, status: number) {
+    return this.feedersRepository.update(id, { status });
   }
 
   remove(id: number) {

--- a/backend/pet-feeder-backend/src/service-orders/dto/complete-service.dto.ts
+++ b/backend/pet-feeder-backend/src/service-orders/dto/complete-service.dto.ts
@@ -1,0 +1,4 @@
+export class CompleteServiceDto {
+  description: string;
+  images: string[];
+}

--- a/backend/pet-feeder-backend/src/service-orders/dto/create-service-order.dto.ts
+++ b/backend/pet-feeder-backend/src/service-orders/dto/create-service-order.dto.ts
@@ -1,0 +1,4 @@
+export class CreateServiceOrderDto {
+  feederId: number;
+  orderId: number;
+}

--- a/backend/pet-feeder-backend/src/service-orders/dto/sign-in.dto.ts
+++ b/backend/pet-feeder-backend/src/service-orders/dto/sign-in.dto.ts
@@ -1,0 +1,4 @@
+export class SignInDto {
+  lat: number;
+  lng: number;
+}

--- a/backend/pet-feeder-backend/src/service-orders/entities/service-order.entity.ts
+++ b/backend/pet-feeder-backend/src/service-orders/entities/service-order.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Feeder } from '../../feeders/entities/feeder.entity';
+import { Order } from '../../orders/entities/order.entity';
+
+@Entity('feeder_service_orders')
+export class ServiceOrder {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Feeder)
+  feeder: Feeder;
+
+  @ManyToOne(() => Order)
+  order: Order;
+
+  @Column('decimal', { precision: 9, scale: 6, nullable: true })
+  signInLat?: number;
+
+  @Column('decimal', { precision: 9, scale: 6, nullable: true })
+  signInLng?: number;
+
+  @Column({ type: 'datetime', nullable: true })
+  signInTime?: Date;
+
+  @Column({ type: 'datetime', nullable: true })
+  completeTime?: Date;
+
+  @Column({ type: 'simple-json', nullable: true })
+  completeImages?: string[];
+
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @Column('tinyint', { default: 0 })
+  status: number;
+
+  @CreateDateColumn()
+  createTime: Date;
+}

--- a/backend/pet-feeder-backend/src/service-orders/service-orders.controller.ts
+++ b/backend/pet-feeder-backend/src/service-orders/service-orders.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { ServiceOrdersService } from './service-orders.service';
+import { CreateServiceOrderDto } from './dto/create-service-order.dto';
+import { SignInDto } from './dto/sign-in.dto';
+import { CompleteServiceDto } from './dto/complete-service.dto';
+
+@Controller('service-orders')
+export class ServiceOrdersController {
+  constructor(private readonly service: ServiceOrdersService) {}
+
+  @Post()
+  create(@Body() dto: CreateServiceOrderDto) {
+    return this.service.create(dto);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(+id);
+  }
+
+  @Patch(':id/sign-in')
+  signIn(@Param('id') id: string, @Body() dto: SignInDto) {
+    return this.service.signIn(+id, dto);
+  }
+
+  @Patch(':id/complete')
+  complete(@Param('id') id: string, @Body() dto: CompleteServiceDto) {
+    return this.service.complete(+id, dto);
+  }
+
+  @Patch(':id/cancel')
+  cancel(@Param('id') id: string) {
+    return this.service.cancel(+id);
+  }
+}

--- a/backend/pet-feeder-backend/src/service-orders/service-orders.module.ts
+++ b/backend/pet-feeder-backend/src/service-orders/service-orders.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ServiceOrdersService } from './service-orders.service';
+import { ServiceOrdersController } from './service-orders.controller';
+import { ServiceOrder } from './entities/service-order.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ServiceOrder])],
+  controllers: [ServiceOrdersController],
+  providers: [ServiceOrdersService],
+})
+export class ServiceOrdersModule {}

--- a/backend/pet-feeder-backend/src/service-orders/service-orders.service.ts
+++ b/backend/pet-feeder-backend/src/service-orders/service-orders.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ServiceOrder } from './entities/service-order.entity';
+import { CreateServiceOrderDto } from './dto/create-service-order.dto';
+import { SignInDto } from './dto/sign-in.dto';
+import { CompleteServiceDto } from './dto/complete-service.dto';
+import { Feeder } from '../feeders/entities/feeder.entity';
+import { Order } from '../orders/entities/order.entity';
+
+@Injectable()
+export class ServiceOrdersService {
+  constructor(
+    @InjectRepository(ServiceOrder)
+    private repository: Repository<ServiceOrder>,
+  ) {}
+
+  create(dto: CreateServiceOrderDto) {
+    const entity = this.repository.create({
+      feeder: { id: dto.feederId } as Feeder,
+      order: { id: dto.orderId } as Order,
+      status: 0,
+    });
+    return this.repository.save(entity);
+  }
+
+  findOne(id: number) {
+    return this.repository.findOne({ where: { id }, relations: ['feeder', 'order'] });
+  }
+
+  signIn(id: number, dto: SignInDto) {
+    return this.repository.update(id, {
+      signInLat: dto.lat,
+      signInLng: dto.lng,
+      signInTime: new Date(),
+      status: 1,
+    });
+  }
+
+  complete(id: number, dto: CompleteServiceDto) {
+    return this.repository.update(id, {
+      completeTime: new Date(),
+      description: dto.description,
+      completeImages: dto.images,
+      status: 2,
+    });
+  }
+
+  cancel(id: number) {
+    return this.repository.update(id, { status: 3 });
+  }
+}

--- a/frontend/admin/README.md
+++ b/frontend/admin/README.md
@@ -1,0 +1,7 @@
+# Admin Frontend
+
+This directory contains a minimal React based admin interface.
+
+## Pages
+- `FeederAudit.jsx` – list feeders pending approval and update status.
+- `OrderList.jsx` – view feeder service orders and uploaded images.

--- a/frontend/admin/src/FeederAudit.jsx
+++ b/frontend/admin/src/FeederAudit.jsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+
+export default function FeederAudit() {
+  const [feeders, setFeeders] = useState([]);
+
+  useEffect(() => {
+    fetch('/feeders')
+      .then((r) => r.json())
+      .then((d) => setFeeders(d.data || []));
+  }, []);
+
+  const updateStatus = (id, status) => {
+    fetch(`/feeders/${id}/status/${status}`, { method: 'PATCH' })
+      .then(() => setFeeders((prev) => prev.filter((f) => f.id !== id)));
+  };
+
+  return (
+    <div>
+      <h2>Feeder Audit</h2>
+      <ul>
+        {feeders.map((f) => (
+          <li key={f.id}>
+            {f.name} - {f.phone}
+            <button onClick={() => updateStatus(f.id, 1)}>Approve</button>
+            <button onClick={() => updateStatus(f.id, 2)}>Reject</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/admin/src/OrderList.jsx
+++ b/frontend/admin/src/OrderList.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+export default function OrderList() {
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    fetch('/service-orders')
+      .then((r) => r.json())
+      .then((d) => setOrders(d.data || []));
+  }, []);
+
+  return (
+    <div>
+      <h2>Service Orders</h2>
+      <ul>
+        {orders.map((o) => (
+          <li key={o.id}>
+            Order #{o.id} - {o.status}
+            {o.completeImages && o.completeImages.map((img) => (
+              <img key={img} src={img} alt="" width="60" />
+            ))}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/feeder-app/README.md
+++ b/frontend/feeder-app/README.md
@@ -1,0 +1,10 @@
+# Feeder Mini Program
+
+Basic pages for feeder workflow.
+
+Pages:
+- `login` – user login and registration.
+- `status` – check approval status.
+- `orders` – list available and accepted orders.
+- `signin` – location sign in.
+- `complete` – submit service completion with images.

--- a/frontend/feeder-app/pages/complete/complete.js
+++ b/frontend/feeder-app/pages/complete/complete.js
@@ -1,0 +1,16 @@
+Page({
+  data: { id: 0, desc: '', images: [] },
+  onLoad(query) {
+    this.setData({ id: query.id });
+  },
+  chooseImage() {
+    wx.chooseMedia({ count: 6, success: (res) => this.setData({ images: res.tempFiles.map(f => f.tempFilePath) }) });
+  },
+  onSubmit() {
+    wx.request({
+      url: `/service-orders/${this.data.id}/complete`,
+      method: 'PATCH',
+      data: { description: this.data.desc, images: this.data.images },
+    });
+  },
+});

--- a/frontend/feeder-app/pages/complete/complete.wxml
+++ b/frontend/feeder-app/pages/complete/complete.wxml
@@ -1,0 +1,3 @@
+<input bindinput="e=>setData({desc:e.detail.value})" placeholder="服务描述" />
+<button bindtap="chooseImage">选择图片</button>
+<button bindtap="onSubmit">提交</button>

--- a/frontend/feeder-app/pages/login/login.js
+++ b/frontend/feeder-app/pages/login/login.js
@@ -1,0 +1,11 @@
+Page({
+  data: {},
+  onLoad() {},
+  onLogin() {
+    wx.login({
+      success: () => {
+        // call backend auth/login
+      },
+    });
+  },
+});

--- a/frontend/feeder-app/pages/login/login.wxml
+++ b/frontend/feeder-app/pages/login/login.wxml
@@ -1,0 +1,1 @@
+<button bindtap="onLogin">微信登录</button>

--- a/frontend/feeder-app/pages/orders/orders.js
+++ b/frontend/feeder-app/pages/orders/orders.js
@@ -1,0 +1,10 @@
+Page({
+  data: { orders: [] },
+  onShow() {
+    wx.request({ url: '/service-orders', success: (res) => this.setData({ orders: res.data.data }) });
+  },
+  accept(e) {
+    const id = e.currentTarget.dataset.id;
+    wx.request({ url: '/service-orders', method: 'POST', data: { feederId: this.data.feederId, orderId: id } });
+  },
+});

--- a/frontend/feeder-app/pages/orders/orders.wxml
+++ b/frontend/feeder-app/pages/orders/orders.wxml
@@ -1,0 +1,4 @@
+<view wx:for="{{orders}}" wx:key="id" data-id="{{item.id}}">
+  <view>{{item.order.id}}</view>
+  <button bindtap="accept" data-id="{{item.order.id}}">接单</button>
+</view>

--- a/frontend/feeder-app/pages/signin/signin.js
+++ b/frontend/feeder-app/pages/signin/signin.js
@@ -1,0 +1,17 @@
+Page({
+  data: { id: 0 },
+  onLoad(query) {
+    this.setData({ id: query.id });
+  },
+  onSign() {
+    wx.getLocation({
+      success: (res) => {
+        wx.request({
+          url: `/service-orders/${this.data.id}/sign-in`,
+          method: 'PATCH',
+          data: { lat: res.latitude, lng: res.longitude },
+        });
+      },
+    });
+  },
+});

--- a/frontend/feeder-app/pages/signin/signin.wxml
+++ b/frontend/feeder-app/pages/signin/signin.wxml
@@ -1,0 +1,1 @@
+<button bindtap="onSign">签到</button>

--- a/frontend/feeder-app/pages/status/status.js
+++ b/frontend/feeder-app/pages/status/status.js
@@ -1,0 +1,6 @@
+Page({
+  data: { status: 0 },
+  onShow() {
+    wx.request({ url: '/feeders/me', success: (res) => this.setData({ status: res.data.data.status }) });
+  },
+});

--- a/frontend/feeder-app/pages/status/status.wxml
+++ b/frontend/feeder-app/pages/status/status.wxml
@@ -1,0 +1,1 @@
+<view>审核状态：{{status}}</view>


### PR DESCRIPTION
## Summary
- expand `Feeder` entity with status and user relation
- allow creating feeders with user ID and updating feeder status
- add `ServiceOrders` module for feeder order workflow
- wire new module into application
- sketch admin React pages and mini-program pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68762ac64bb88320b35eb020d4ea6491