### PR TITLE
Add E2E tests for user flow

### DIFF
--- a/backend/pet-feeder-backend/package-lock.json
+++ b/backend/pet-feeder-backend/package-lock.json
@@ -15,13 +15,16 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/platform-socket.io": "^11.1.4",
         "@nestjs/typeorm": "^11.0.0",
+        "@nestjs/websockets": "^11.1.4",
         "axios": "^1.10.0",
         "mysql2": "^3.9.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "socket.io": "^4.8.1",
         "typeorm": "^0.3.25"
       },
       "devDependencies": {
@@ -2598,6 +2601,25 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.4.tgz",
+      "integrity": "sha512-1BSDCc3aUG2JPjS5DIK4MVbtC9tBV4YYi99WYIAup6oB9p1ys0MIxE2n5end3iP+wt1Z942Kh28HzjX7aEG0hA==",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "4.8.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.5.tgz",
@@ -2735,6 +2757,29 @@
         "reflect-metadata": "^0.1.13 || ^0.2.0",
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.0"
+      }
+    },
+    "node_modules/@nestjs/websockets": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.4.tgz",
+      "integrity": "sha512-TUnEtOrhzKtjlgeezYzKohN/T/ZKEzANOeSkU1YWlamOv+vXVcsZuW7BjGdaBzvH3Jt3SmhDOyUvGv5NvmV/RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/platform-socket.io": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-socket.io": {
+          "optional": true
+        }
       }
     },
     "node_modules/@noble/hashes": {
@@ -2925,6 +2970,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
@@ -3377,6 +3428,15 @@
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -5186,6 +5246,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/bin-version": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-6.0.0.tgz",
@@ -6469,6 +6538,95 @@
       "peer": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -10410,6 +10568,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -11907,6 +12074,141 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/socks": {
@@ -13980,6 +14282,27 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/backend/pet-feeder-backend/package.json
+++ b/backend/pet-feeder-backend/package.json
@@ -26,13 +26,16 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/platform-socket.io": "^11.1.4",
     "@nestjs/typeorm": "^11.0.0",
+    "@nestjs/websockets": "^11.1.4",
     "axios": "^1.10.0",
     "mysql2": "^3.9.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "socket.io": "^4.8.1",
     "typeorm": "^0.3.25"
   },
   "devDependencies": {

--- a/backend/pet-feeder-backend/src/service-orders/service-orders.service.ts
+++ b/backend/pet-feeder-backend/src/service-orders/service-orders.service.ts
@@ -33,7 +33,10 @@ export class ServiceOrdersService {
   }
 
   findOne(id: number) {
-    return this.repository.findOne({ where: { id }, relations: ['feeder', 'order'] });
+    return this.repository.findOne({
+      where: { id },
+      relations: ['feeder', 'order', 'order.user'],
+    });
   }
 
   signIn(id: number, dto: SignInDto) {
@@ -75,9 +78,9 @@ export class ServiceOrdersService {
     const tpl = templateMap[status];
     if (tpl) {
       const detail = await this.findOne(id);
-      const openid = detail.order.user?.openid;
+      const openid = detail?.order?.user?.openid;
       if (openid) {
-        this.wxService.send(openid, tpl, { status }, `/pages/orders/detail?id=${detail.order.id}`);
+        this.wxService.send(openid, tpl, { status }, `/pages/orders/detail?id=${detail!.order.id}`);
       }
     }
     return res;

--- a/backend/pet-feeder-backend/src/tracking/tracking.module.ts
+++ b/backend/pet-feeder-backend/src/tracking/tracking.module.ts
@@ -11,6 +11,6 @@ import { WxTemplateService } from './wx-template.service';
   imports: [TypeOrmModule.forFeature([ServiceOrder, FeederLocation])],
   providers: [TrackingService, TrackingGateway, WxTemplateService],
   controllers: [TrackingController],
-  exports: [TrackingGateway, TrackingService],
+  exports: [TrackingGateway, TrackingService, WxTemplateService],
 })
 export class TrackingModule {}

--- a/backend/pet-feeder-backend/test/app.e2e-spec.ts
+++ b/backend/pet-feeder-backend/test/app.e2e-spec.ts
@@ -2,14 +2,61 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersModule } from '../src/users/users.module';
+import { PetsModule } from '../src/pets/pets.module';
+import { OrdersModule } from '../src/orders/orders.module';
+import { FeedersModule } from '../src/feeders/feeders.module';
+import { ServiceOrdersModule } from '../src/service-orders/service-orders.module';
+import { TrackingModule } from '../src/tracking/tracking.module';
+import { AuthModule } from '../src/auth/auth.module';
+import { AdminModule } from '../src/admin/admin.module';
+import { User } from '../src/users/entities/user.entity';
+import { Pet } from '../src/pets/entities/pet.entity';
+import { Order } from '../src/orders/entities/order.entity';
+import { Feeder } from '../src/feeders/entities/feeder.entity';
+import { ServiceOrder } from '../src/service-orders/entities/service-order.entity';
+import { FeederLocation } from '../src/tracking/entities/feeder-location.entity';
+import { EmergencyCall } from '../src/im/entities/emergency-call.entity';
+import { AdminUser } from '../src/admin/entities/admin-user.entity';
+import { AdminOperationLog } from '../src/admin/entities/admin-operation-log.entity';
+import { AppController } from '../src/app.controller';
+import { AppService } from '../src/app.service';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          dropSchema: true,
+          entities: [
+            User,
+            Pet,
+            Order,
+            Feeder,
+            ServiceOrder,
+            FeederLocation,
+            EmergencyCall,
+            AdminUser,
+            AdminOperationLog,
+          ],
+          synchronize: true,
+        }),
+        UsersModule,
+        PetsModule,
+        OrdersModule,
+        FeedersModule,
+        ServiceOrdersModule,
+        TrackingModule,
+        AuthModule,
+        AdminModule,
+      ],
+      controllers: [AppController],
+      providers: [AppService],
     }).compile();
 
     app = moduleFixture.createNestApplication();

--- a/backend/pet-feeder-backend/test/user-flow.e2e-spec.ts
+++ b/backend/pet-feeder-backend/test/user-flow.e2e-spec.ts
@@ -1,0 +1,210 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import * as request from 'supertest';
+import { UsersModule } from '../src/users/users.module';
+import { PetsModule } from '../src/pets/pets.module';
+import { OrdersModule } from '../src/orders/orders.module';
+import { FeedersModule } from '../src/feeders/feeders.module';
+import { ServiceOrdersModule } from '../src/service-orders/service-orders.module';
+import { TrackingModule } from '../src/tracking/tracking.module';
+import { AuthModule } from '../src/auth/auth.module';
+import { AdminModule } from '../src/admin/admin.module';
+import { LoggingInterceptor } from '../src/common/interceptors/logging.interceptor';
+import { ResponseInterceptor } from '../src/common/interceptors/response.interceptor';
+import { User } from '../src/users/entities/user.entity';
+import { Pet } from '../src/pets/entities/pet.entity';
+import { Order } from '../src/orders/entities/order.entity';
+import { Feeder } from '../src/feeders/entities/feeder.entity';
+import { ServiceOrder } from '../src/service-orders/entities/service-order.entity';
+import { FeederLocation } from '../src/tracking/entities/feeder-location.entity';
+import { EmergencyCall } from '../src/im/entities/emergency-call.entity';
+import { AdminUser } from '../src/admin/entities/admin-user.entity';
+import { AdminOperationLog } from '../src/admin/entities/admin-operation-log.entity';
+import { WxTemplateService } from '../src/tracking/wx-template.service';
+import { ServiceStatus } from '../src/service-orders/status.enum';
+
+/**
+ * Helper to bootstrap application with in-memory sqlite database.
+ */
+async function createTestApp() {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [
+      TypeOrmModule.forRoot({
+        type: 'sqlite',
+        database: ':memory:',
+        dropSchema: true,
+        entities: [
+          User,
+          Pet,
+          Order,
+          Feeder,
+          ServiceOrder,
+          FeederLocation,
+          EmergencyCall,
+          AdminUser,
+          AdminOperationLog,
+        ],
+        synchronize: true,
+      }),
+      UsersModule,
+      PetsModule,
+      OrdersModule,
+      FeedersModule,
+      ServiceOrdersModule,
+      TrackingModule,
+      AuthModule,
+      AdminModule,
+    ],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  app.useGlobalInterceptors(new LoggingInterceptor(), new ResponseInterceptor());
+  await app.init();
+  return app;
+}
+
+/**
+ * Validate basic structure and types of response data.
+ */
+function expectPetShape(pet: any) {
+  expect(pet).toEqual(
+    expect.objectContaining({
+      id: expect.any(Number),
+      name: expect.any(String),
+      species: expect.any(String),
+    }),
+  );
+}
+
+function expectOrderShape(order: any) {
+  expect(order).toEqual(
+    expect.objectContaining({
+      id: expect.any(Number),
+      startTime: expect.any(String),
+      endTime: expect.any(String),
+      status: expect.any(String),
+    }),
+  );
+}
+
+/**
+ * End-to-end user flow tests.
+ */
+describe('User core flow (e2e)', () => {
+  let app: INestApplication;
+  let server: any;
+  let token: string;
+  let petId: number;
+  let orderId: number;
+  let serviceOrderId: number;
+  let wxService: WxTemplateService;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    server = app.getHttpServer();
+    wxService = app.get(WxTemplateService);
+    jest.spyOn(wxService, 'send').mockResolvedValue(undefined);
+
+    // login to obtain JWT
+    const loginRes = await request(server)
+      .post('/auth/login')
+      .send({ openid: 'user_openid', nickname: 'TestUser' });
+    token = loginRes.body.data.access_token;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should complete add pet -> reserve -> pay -> service flow', async () => {
+    // create pet
+    const petRes = await request(server)
+      .post('/pets')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ userId: 1, name: 'Kitty', species: 'cat', age: 1 });
+    expect(petRes.status).toBe(201);
+    expectPetShape(petRes.body.data);
+    petId = petRes.body.data.id;
+
+    // create order
+    const start = new Date().toISOString();
+    const end = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const orderRes = await request(server)
+      .post('/orders')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ userId: 1, petId, startTime: start, endTime: end, status: 'reserved' });
+    expect(orderRes.status).toBe(201);
+    expectOrderShape(orderRes.body.data);
+    expect(orderRes.body.data.status).toBe('reserved');
+    orderId = orderRes.body.data.id;
+
+    // simulate payment by updating status
+    const payRes = await request(server)
+      .patch(`/orders/${orderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'paid' });
+    expect(payRes.status).toBe(200);
+
+    // create feeder and service order
+    const uRes = await request(server)
+      .post('/users')
+      .send({ openid: 'feeder_openid', nickname: 'Feeder' });
+    const feederRes = await request(server)
+      .post('/feeders')
+      .send({
+        userId: uRes.body.data.id,
+        name: 'Feeder',
+        phone: '13900000000',
+        idCard: '110101199001010000',
+      });
+    const feederId = feederRes.body.data.id;
+
+    const serviceRes = await request(server)
+      .post('/service-orders')
+      .send({ feederId, orderId });
+    serviceOrderId = serviceRes.body.data.id;
+    expect(serviceRes.body.data.status).toBe(ServiceStatus.ACCEPTED);
+
+    // depart
+    await request(server).patch(`/service-orders/${serviceOrderId}/depart`).send();
+    let detail = await request(server).get(`/service-orders/${serviceOrderId}`);
+    expect(detail.body.data.status).toBe(ServiceStatus.DEPARTED);
+
+    // sign in
+    await request(server)
+      .patch(`/service-orders/${serviceOrderId}/sign-in`)
+      .send({ lat: 30.1, lng: 120.2 });
+    detail = await request(server).get(`/service-orders/${serviceOrderId}`);
+    expect(detail.body.data.status).toBe(ServiceStatus.SIGNED_IN);
+
+    // start service
+    await request(server).patch(`/service-orders/${serviceOrderId}/start`).send();
+    detail = await request(server).get(`/service-orders/${serviceOrderId}`);
+    expect(detail.body.data.status).toBe(ServiceStatus.SERVING);
+
+    // complete service
+    await request(server)
+      .patch(`/service-orders/${serviceOrderId}/complete`)
+      .send({ description: 'done', images: [] });
+    detail = await request(server).get(`/service-orders/${serviceOrderId}`);
+    expect(detail.body.data.status).toBe(ServiceStatus.COMPLETED);
+    expect(wxService.send).toHaveBeenCalled();
+  });
+
+  it('should reject unauthorized pet creation', async () => {
+    await request(server)
+      .post('/pets')
+      .send({ userId: 1, name: 'Bad', species: 'cat' })
+      .expect(401);
+  });
+
+  it('should cancel service order', async () => {
+    const cancelRes = await request(server)
+      .patch(`/service-orders/${serviceOrderId}/cancel`)
+      .send();
+    expect(cancelRes.status).toBe(200);
+    const detail = await request(server).get(`/service-orders/${serviceOrderId}`);
+    expect(detail.body.data.status).toBe(ServiceStatus.CANCELED);
+  });
+});


### PR DESCRIPTION
## Summary
- add end-to-end tests covering user flows and authorization
- fix service-orders retrieval and notification logic
- export WxTemplateService from tracking module
- adjust existing e2e test to run with sqlite
- include websocket dependencies

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6878502c037883208fb704c69f87d9c3