### PR TITLE
Add tracking module unit tests

### DIFF
--- a/backend/pet-feeder-backend/package-lock.json
+++ b/backend/pet-feeder-backend/package-lock.json
@@ -17,7 +17,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.1.4",
         "@nestjs/typeorm": "^11.0.0",
-        "@nestjs/websockets": "^11.1.4",
+        "@nestjs/websockets": "^11.0.0",
         "axios": "^1.10.0",
         "mysql2": "^3.9.0",
         "passport": "^0.7.0",
@@ -45,6 +45,7 @@
         "globals": "^16.0.0",
         "jest": "^29.7.0",
         "prettier": "^3.4.2",
+        "socket.io-client": "^4.7.5",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
@@ -6560,6 +6561,38 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -12121,6 +12154,40 @@
         }
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -14302,6 +14369,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/backend/pet-feeder-backend/package.json
+++ b/backend/pet-feeder-backend/package.json
@@ -37,7 +37,7 @@
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.25",
     "@nestjs/websockets": "^11.0.0",
-    "socket.io": "^4.8.1",
+    "socket.io": "^4.8.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -57,6 +57,7 @@
     "globals": "^16.0.0",
     "jest": "^29.7.0",
     "prettier": "^3.4.2",
+    "socket.io-client": "^4.7.5",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",

--- a/backend/pet-feeder-backend/src/service-orders/__tests__/service-orders.service.spec.ts
+++ b/backend/pet-feeder-backend/src/service-orders/__tests__/service-orders.service.spec.ts
@@ -1,0 +1,46 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ServiceOrdersService } from '../service-orders.service';
+import { ServiceOrder } from '../entities/service-order.entity';
+import { TrackingGateway } from '../../tracking/tracking.gateway';
+import { WxTemplateService } from '../../tracking/wx-template.service';
+import { ServiceStatus } from '../status.enum';
+
+describe('ServiceOrdersService status flow', () => {
+  let service: ServiceOrdersService;
+  const repo: any = {
+    update: jest.fn(),
+    findOne: jest.fn(),
+  };
+  const gateway: any = { notifyStatus: jest.fn() };
+  const wx: any = { send: jest.fn(), logger: { error: jest.fn() } };
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        ServiceOrdersService,
+        { provide: getRepositoryToken(ServiceOrder), useValue: repo },
+        { provide: TrackingGateway, useValue: gateway },
+        { provide: WxTemplateService, useValue: wx },
+      ],
+    }).compile();
+    service = module.get(ServiceOrdersService);
+    jest.clearAllMocks();
+    repo.findOne.mockResolvedValue({ id: 1, order: { id: 2, user: { openid: 'o' } } });
+    repo.update.mockResolvedValue({ affected: 1 });
+  });
+
+  it('should notify status and send template on sign in', async () => {
+    await service.signIn(1, { lat: 1, lng: 2 });
+    expect(gateway.notifyStatus).toHaveBeenCalledWith(1, ServiceStatus.SIGNED_IN);
+    expect(repo.update).toHaveBeenCalled();
+    expect(wx.send).toHaveBeenCalledWith('o', 'signin_tpl', { status: ServiceStatus.SIGNED_IN }, '/pages/orders/detail?id=2');
+  });
+
+  it('should notify status on complete', async () => {
+    await service.complete(1, { description: 'done', images: [] });
+    expect(gateway.notifyStatus).toHaveBeenCalledWith(1, ServiceStatus.COMPLETED);
+    expect(wx.send).toHaveBeenCalledWith('o', 'complete_tpl', { status: ServiceStatus.COMPLETED }, '/pages/orders/detail?id=2');
+  });
+});

--- a/backend/pet-feeder-backend/src/tracking/__tests__/tracking.service.spec.ts
+++ b/backend/pet-feeder-backend/src/tracking/__tests__/tracking.service.spec.ts
@@ -1,0 +1,36 @@
+import { TrackingService } from '../tracking.service';
+import { TrackingGateway } from '../tracking.gateway';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import { ServiceOrder } from '../../service-orders/entities/service-order.entity';
+import { FeederLocation } from '../entities/feeder-location.entity';
+
+describe('TrackingService', () => {
+  let service: TrackingService;
+  const orders: any = { findOne: jest.fn() };
+  const locations: any = { create: jest.fn(), save: jest.fn() };
+  const gateway: any = { notifyLocation: jest.fn() };
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        TrackingService,
+        { provide: getRepositoryToken(ServiceOrder), useValue: orders },
+        { provide: getRepositoryToken(FeederLocation), useValue: locations },
+        { provide: TrackingGateway, useValue: gateway },
+      ],
+    }).compile();
+    service = module.get(TrackingService);
+    jest.clearAllMocks();
+    locations.create.mockImplementation((d) => d);
+    locations.save.mockImplementation((d) => Promise.resolve({ id: 1, ...d, createTime: new Date() }));
+  });
+
+  it('should save location and notify gateway', async () => {
+    await service.reportLocation(5, { lat: 1, lng: 2 });
+    expect(locations.create).toHaveBeenCalled();
+    expect(locations.save).toHaveBeenCalled();
+    expect(gateway.notifyLocation).toHaveBeenCalledWith(5, expect.objectContaining({ lat: 1, lng: 2 }));
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for service order status transitions
- add unit tests for tracking location updates
- include socket.io-client as dev dependency

## Testing
- `npm test -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_6878f6559b0883209442f2fba281e913