### PR TITLE
Add IM tests and fix ServiceOrdersService spec

### DIFF
--- a/backend/pet-feeder-backend/src/im/__tests__/im.module.spec.ts
+++ b/backend/pet-feeder-backend/src/im/__tests__/im.module.spec.ts
@@ -1,0 +1,69 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ImService } from '../im.service';
+import { ImGateway } from '../im.gateway';
+import { Message } from '../entities/message.entity';
+import { MessageType } from '../message-type.enum';
+
+const repo = {
+  create: jest.fn(),
+  save: jest.fn(),
+  createQueryBuilder: jest.fn(),
+};
+
+const mockServer = { to: jest.fn().mockReturnThis(), emit: jest.fn() } as any;
+
+const buildQb = () => ({
+  where: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  getMany: jest.fn(),
+});
+
+describe('IM module', () => {
+  let service: ImService;
+  let gateway: ImGateway;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        ImService,
+        ImGateway,
+        { provide: getRepositoryToken(Message), useValue: repo },
+      ],
+    }).compile();
+    service = module.get(ImService);
+    gateway = module.get(ImGateway);
+    (gateway as any).server = mockServer;
+    jest.clearAllMocks();
+  });
+
+  it('should join room on connection', () => {
+    const socket: any = { handshake: { query: { orderId: 5 } }, join: jest.fn() };
+    gateway.handleConnection(socket);
+    expect(socket.join).toHaveBeenCalledWith('5');
+  });
+
+  const dtoBase = { receiverId: 2, orderId: 5, payload: {} };
+  const types = [MessageType.TEXT, MessageType.IMAGE, MessageType.VOICE, MessageType.LOCATION];
+
+  it.each(types)('should store %s message', async (type) => {
+    repo.create.mockImplementation((d) => d);
+    repo.save.mockResolvedValue({ id: 1, senderId: 1, type });
+    const dto = { ...dtoBase, type } as any;
+    const msg = await service.send(1, dto);
+    expect(repo.save).toHaveBeenCalledWith(expect.objectContaining({ type }));
+    await gateway.handleMessage(5, msg);
+    expect(mockServer.emit).toHaveBeenCalledWith('message', msg);
+  });
+
+  it('should query history', async () => {
+    const qb = buildQb();
+    repo.createQueryBuilder.mockReturnValue(qb);
+    qb.getMany.mockResolvedValue([]);
+    await service.history(5);
+    expect(qb.where).toHaveBeenCalled();
+    expect(qb.getMany).toHaveBeenCalled();
+  });
+});

--- a/backend/pet-feeder-backend/src/service-orders/__tests__/service-orders.service.spec.ts
+++ b/backend/pet-feeder-backend/src/service-orders/__tests__/service-orders.service.spec.ts
@@ -3,6 +3,8 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ServiceOrdersService } from '../service-orders.service';
 import { ServiceOrder } from '../entities/service-order.entity';
+import { Feeder } from '../../feeders/entities/feeder.entity';
+import { Order } from '../../orders/entities/order.entity';
 import { TrackingGateway } from '../../tracking/tracking.gateway';
 import { WxTemplateService } from '../../tracking/wx-template.service';
 import { ServiceStatus } from '../status.enum';
@@ -13,6 +15,8 @@ describe('ServiceOrdersService status flow', () => {
     update: jest.fn(),
     findOne: jest.fn(),
   };
+  const feederRepo = {} as Repository<any>;
+  const orderRepo = {} as Repository<any>;
   const gateway: any = { notifyStatus: jest.fn() };
   const wx: any = { send: jest.fn(), logger: { error: jest.fn() } };
 
@@ -21,6 +25,8 @@ describe('ServiceOrdersService status flow', () => {
       providers: [
         ServiceOrdersService,
         { provide: getRepositoryToken(ServiceOrder), useValue: repo },
+        { provide: getRepositoryToken(Feeder), useValue: feederRepo },
+        { provide: getRepositoryToken(Order), useValue: orderRepo },
         { provide: TrackingGateway, useValue: gateway },
         { provide: WxTemplateService, useValue: wx },
       ],


### PR DESCRIPTION
## Summary
- cover IM gateway/service with Jest tests
- provide Feeder and Order repo mocks for ServiceOrdersService unit tests

## Testing
- `cd backend/pet-feeder-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68799b0ae360832099d26dcd46f3bba8