### PR TITLE
Ensure e2e tests run sequentially

### DIFF
--- a/backend/pet-feeder-backend/test/jest-e2e.json
+++ b/backend/pet-feeder-backend/test/jest-e2e.json
@@ -1,9 +1,15 @@
 {
-  "moduleFileExtensions": ["js", "json", "ts"],
+  "moduleFileExtensions": [
+    "js",
+    "json",
+    "ts"
+  ],
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "testSequencer": "<rootDir>/test-sequencer.js",
+  "maxWorkers": 1
 }

--- a/backend/pet-feeder-backend/test/test-sequencer.js
+++ b/backend/pet-feeder-backend/test/test-sequencer.js
@@ -1,0 +1,21 @@
+const Sequencer = require('@jest/test-sequencer').default;
+const path = require('path');
+
+class CustomSequencer extends Sequencer {
+  sort(tests) {
+    const order = [
+      'app.e2e-spec.ts',
+      'user-flow.e2e-spec.ts',
+      'feeder-workflow.e2e-spec.ts',
+      'admin-workflow.e2e-spec.ts',
+    ];
+    const rank = (test) => {
+      const file = path.basename(test.path);
+      const idx = order.indexOf(file);
+      return idx === -1 ? order.length : idx;
+    };
+    return Array.from(tests).sort((a, b) => rank(a) - rank(b));
+  }
+}
+
+module.exports = CustomSequencer;


### PR DESCRIPTION
## Summary
- enforce the execution order of e2e specs
- run test suites in a single worker

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_687a1ae8823883208ab4808f4d244d6f