### PR TITLE
Add feeder orders module

### DIFF
--- a/backend/pet-feeder-backend/src/app.module.ts
+++ b/backend/pet-feeder-backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { TrackingModule } from './tracking/tracking.module';
 import { EvaluationsModule } from './evaluations/evaluations.module';
 import { FeedbackModule } from './feedback/feedback.module';
 import { ComplaintsModule } from './complaints/complaints.module';
+import { FeederOrdersModule } from './feeder-orders/feeder-orders.module';
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { ComplaintsModule } from './complaints/complaints.module';
     EvaluationsModule,
     FeedbackModule,
     ComplaintsModule,
+    FeederOrdersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/pet-feeder-backend/src/feeder-orders/dto/complete-feeder-order.dto.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/dto/complete-feeder-order.dto.ts
@@ -1,0 +1,4 @@
+export class CompleteFeederOrderDto {
+  images?: string[];
+  remark?: string;
+}

--- a/backend/pet-feeder-backend/src/feeder-orders/dto/create-feeder-order.dto.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/dto/create-feeder-order.dto.ts
@@ -1,0 +1,7 @@
+export class CreateFeederOrderDto {
+  userId: number;
+  feederId: number;
+  petId: number;
+  serviceTime: Date;
+  address: string;
+}

--- a/backend/pet-feeder-backend/src/feeder-orders/dto/paginate-feeder-order.dto.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/dto/paginate-feeder-order.dto.ts
@@ -1,0 +1,4 @@
+export class PaginateFeederOrderDto {
+  page: number;
+  limit: number;
+}

--- a/backend/pet-feeder-backend/src/feeder-orders/entities/feeder-order.entity.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/entities/feeder-order.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Feeder } from '../../feeders/entities/feeder.entity';
+import { Pet } from '../../pets/entities/pet.entity';
+
+export enum FeederOrderStatus {
+  PENDING = 'pending',
+  ACCEPTED = 'accepted',
+  REJECTED = 'rejected',
+  SERVING = 'serving',
+  COMPLETED = 'completed',
+}
+
+@Entity('feeder_orders')
+export class FeederOrder {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User)
+  user: User;
+
+  @ManyToOne(() => Feeder)
+  feeder: Feeder;
+
+  @ManyToOne(() => Pet)
+  pet: Pet;
+
+  @Column('datetime')
+  serviceTime: Date;
+
+  @Column({ length: 200 })
+  address: string;
+
+  @Column({
+    type: 'enum',
+    enum: FeederOrderStatus,
+    default: FeederOrderStatus.PENDING,
+  })
+  status: FeederOrderStatus;
+
+  @Column({ type: 'simple-json', nullable: true })
+  images?: string[];
+
+  @Column({ type: 'text', nullable: true })
+  remark?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.controller.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { FeederOrdersService } from './feeder-orders.service';
+import { CreateFeederOrderDto } from './dto/create-feeder-order.dto';
+import { CompleteFeederOrderDto } from './dto/complete-feeder-order.dto';
+import { PaginateFeederOrderDto } from './dto/paginate-feeder-order.dto';
+
+@Controller('feeder-orders')
+export class FeederOrdersController {
+  constructor(private readonly service: FeederOrdersService) {}
+
+  /** 创建订单（测试用） */
+  @Post()
+  create(@Body() dto: CreateFeederOrderDto) {
+    return this.service.create(dto);
+  }
+
+  /** 获取喂养员的所有订单 */
+  @Get('feeder/:feederId')
+  findByFeeder(
+    @Param('feederId') feederId: string,
+    @Query() query: PaginateFeederOrderDto,
+  ) {
+    const page = Number(query.page) || 1;
+    const limit = Number(query.limit) || 10;
+    return this.service.paginateByFeeder(+feederId, page, limit);
+  }
+
+  /** 确认订单 */
+  @Patch(':id/confirm')
+  confirm(@Param('id') id: string) {
+    return this.service.confirm(+id);
+  }
+
+  /** 拒绝订单 */
+  @Patch(':id/reject')
+  reject(@Param('id') id: string) {
+    return this.service.reject(+id);
+  }
+
+  /** 开始服务 */
+  @Patch(':id/start')
+  start(@Param('id') id: string) {
+    return this.service.start(+id);
+  }
+
+  /** 完成服务并上传图片、备注 */
+  @Patch(':id/complete')
+  complete(@Param('id') id: string, @Body() dto: CompleteFeederOrderDto) {
+    return this.service.complete(+id, dto);
+  }
+}

--- a/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.module.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FeederOrdersService } from './feeder-orders.service';
+import { FeederOrdersController } from './feeder-orders.controller';
+import { FeederOrder } from './entities/feeder-order.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FeederOrder])],
+  controllers: [FeederOrdersController],
+  providers: [FeederOrdersService],
+})
+export class FeederOrdersModule {}

--- a/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.service.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FeederOrder, FeederOrderStatus } from './entities/feeder-order.entity';
+import { CreateFeederOrderDto } from './dto/create-feeder-order.dto';
+import { CompleteFeederOrderDto } from './dto/complete-feeder-order.dto';
+import { User } from '../users/entities/user.entity';
+import { Feeder } from '../feeders/entities/feeder.entity';
+import { Pet } from '../pets/entities/pet.entity';
+
+@Injectable()
+export class FeederOrdersService {
+  constructor(
+    @InjectRepository(FeederOrder)
+    private orders: Repository<FeederOrder>,
+  ) {}
+
+  create(dto: CreateFeederOrderDto) {
+    const entity = this.orders.create({
+      user: { id: dto.userId } as User,
+      feeder: { id: dto.feederId } as Feeder,
+      pet: { id: dto.petId } as Pet,
+      serviceTime: dto.serviceTime,
+      address: dto.address,
+      status: FeederOrderStatus.PENDING,
+    });
+    return this.orders.save(entity);
+  }
+
+  async paginateByFeeder(feederId: number, page: number, limit: number) {
+    const [items, total] = await this.orders.findAndCount({
+      where: { feeder: { id: feederId } },
+      relations: ['user', 'pet', 'feeder'],
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return { items, total, page, limit };
+  }
+
+  private async get(id: number) {
+    const order = await this.orders.findOne({ where: { id } });
+    if (!order) throw new NotFoundException('Order not found');
+    return order;
+  }
+
+  async confirm(id: number) {
+    const order = await this.get(id);
+    order.status = FeederOrderStatus.ACCEPTED;
+    return this.orders.save(order);
+  }
+
+  async reject(id: number) {
+    const order = await this.get(id);
+    order.status = FeederOrderStatus.REJECTED;
+    return this.orders.save(order);
+  }
+
+  async start(id: number) {
+    const order = await this.get(id);
+    order.status = FeederOrderStatus.SERVING;
+    return this.orders.save(order);
+  }
+
+  async complete(id: number, dto: CompleteFeederOrderDto) {
+    const order = await this.get(id);
+    order.status = FeederOrderStatus.COMPLETED;
+    order.images = dto.images;
+    order.remark = dto.remark;
+    return this.orders.save(order);
+  }
+}

--- a/backend/pet-feeder-backend/src/service-orders/__tests__/service-orders.service.spec.ts
+++ b/backend/pet-feeder-backend/src/service-orders/__tests__/service-orders.service.spec.ts
@@ -7,8 +7,6 @@ import { Feeder } from '../../feeders/entities/feeder.entity';
 import { Order } from '../../orders/entities/order.entity';
 import { TrackingGateway } from '../../tracking/tracking.gateway';
 import { WxTemplateService } from '../../tracking/wx-template.service';
-import { Feeder } from '../../feeders/entities/feeder.entity';
-import { Order } from '../../orders/entities/order.entity';
 import { ServiceStatus } from '../status.enum';
 
 describe('ServiceOrdersService status flow', () => {
@@ -35,20 +33,39 @@ describe('ServiceOrdersService status flow', () => {
     }).compile();
     service = module.get(ServiceOrdersService);
     jest.clearAllMocks();
-    repo.findOne.mockResolvedValue({ id: 1, order: { id: 2, user: { openid: 'o' } } });
+    repo.findOne.mockResolvedValue({
+      id: 1,
+      order: { id: 2, user: { openid: 'o' } },
+    });
     repo.update.mockResolvedValue({ affected: 1 });
   });
 
   it('should notify status and send template on sign in', async () => {
     await service.signIn(1, { lat: 1, lng: 2 });
-    expect(gateway.notifyStatus).toHaveBeenCalledWith(1, ServiceStatus.SIGNED_IN);
+    expect(gateway.notifyStatus).toHaveBeenCalledWith(
+      1,
+      ServiceStatus.SIGNED_IN,
+    );
     expect(repo.update).toHaveBeenCalled();
-    expect(wx.send).toHaveBeenCalledWith('o', 'signin_tpl', { status: ServiceStatus.SIGNED_IN }, '/pages/orders/detail?id=2');
+    expect(wx.send).toHaveBeenCalledWith(
+      'o',
+      'signin_tpl',
+      { status: ServiceStatus.SIGNED_IN },
+      '/pages/orders/detail?id=2',
+    );
   });
 
   it('should notify status on complete', async () => {
     await service.complete(1, { description: 'done', images: [] });
-    expect(gateway.notifyStatus).toHaveBeenCalledWith(1, ServiceStatus.COMPLETED);
-    expect(wx.send).toHaveBeenCalledWith('o', 'complete_tpl', { status: ServiceStatus.COMPLETED }, '/pages/orders/detail?id=2');
+    expect(gateway.notifyStatus).toHaveBeenCalledWith(
+      1,
+      ServiceStatus.COMPLETED,
+    );
+    expect(wx.send).toHaveBeenCalledWith(
+      'o',
+      'complete_tpl',
+      { status: ServiceStatus.COMPLETED },
+      '/pages/orders/detail?id=2',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add FeederOrders module to let feeders manage service orders
- wire FeederOrdersModule in app module
- fix duplicate imports in existing service order test

## Testing
- `npm test`
- `npm run lint` *(fails: 4 errors, 107 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687a5479b16c8320bb8a880975be4376