### PR TITLE
Implement feeder registration workflow

### DIFF
--- a/backend/pet-feeder-backend/src/admin/admin.controller.ts
+++ b/backend/pet-feeder-backend/src/admin/admin.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Patch, Param, Query, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Roles } from '../common/decorators/roles.decorator';
 import { RolesGuard } from '../common/guards/roles.guard';
@@ -23,6 +23,19 @@ export class AdminController {
   @Roles('admin')
   auditFeeder(@Body() dto: AuditFeederDto) {
     return this.service.auditFeeder(dto);
+  }
+
+  @Patch('feeders/:id/audit')
+  @Roles('admin')
+  auditFeederById(
+    @Param('id') id: string,
+    @Body() dto: Omit<AuditFeederDto, 'feederId'>,
+  ) {
+    return this.service.auditFeeder({
+      feederId: parseInt(id, 10),
+      approve: dto.approve,
+      reason: dto.reason,
+    });
   }
 
   @Post('orders/update-status')

--- a/backend/pet-feeder-backend/src/admin/admin.service.ts
+++ b/backend/pet-feeder-backend/src/admin/admin.service.ts
@@ -27,6 +27,7 @@ export class AdminService {
     const status = dto.approve ? 1 : 2;
     return this.feedersRepository.update(dto.feederId, {
       status,
+      rejectReason: dto.approve ? null : dto.reason,
     });
   }
 

--- a/backend/pet-feeder-backend/src/feeders/dto/apply-feeder.dto.ts
+++ b/backend/pet-feeder-backend/src/feeders/dto/apply-feeder.dto.ts
@@ -1,0 +1,6 @@
+export class ApplyFeederDto {
+  name: string;
+  phone: string;
+  idCard: string;
+  avatar?: string;
+}

--- a/backend/pet-feeder-backend/src/feeders/dto/create-feeder.dto.ts
+++ b/backend/pet-feeder-backend/src/feeders/dto/create-feeder.dto.ts
@@ -5,4 +5,5 @@ export class CreateFeederDto {
   idCard: string;
   avatar?: string;
   rating?: number;
+  rejectReason?: string;
 }

--- a/backend/pet-feeder-backend/src/feeders/entities/feeder.entity.ts
+++ b/backend/pet-feeder-backend/src/feeders/entities/feeder.entity.ts
@@ -33,6 +33,9 @@ export class Feeder {
   @Column('tinyint', { default: 0 })
   status: number;
 
+  @Column({ length: 255, nullable: true })
+  rejectReason?: string;
+
   @Column('tinyint', { default: 0 })
   isBlacklist: number;
 

--- a/backend/pet-feeder-backend/src/feeders/feeder-self.controller.ts
+++ b/backend/pet-feeder-backend/src/feeders/feeder-self.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { FeedersService } from './feeders.service';
+import { ApplyFeederDto } from './dto/apply-feeder.dto';
+
+@Controller('feeder')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class FeederSelfController {
+  constructor(private readonly service: FeedersService) {}
+
+  @Post('apply')
+  @Roles('user')
+  apply(@Req() req, @Body() dto: ApplyFeederDto) {
+    return this.service.apply(req.user.id, dto);
+  }
+
+  @Get('profile')
+  @Roles('user', 'feeder', 'admin')
+  profile(@Req() req) {
+    return this.service.findByUserId(req.user.id);
+  }
+}

--- a/backend/pet-feeder-backend/src/feeders/feeders.module.ts
+++ b/backend/pet-feeder-backend/src/feeders/feeders.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FeedersService } from './feeders.service';
 import { FeedersController } from './feeders.controller';
+import { FeederSelfController } from './feeder-self.controller';
 import { Feeder } from './entities/feeder.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Feeder])],
-  controllers: [FeedersController],
+  controllers: [FeedersController, FeederSelfController],
   providers: [FeedersService],
 })
 export class FeedersModule {}

--- a/backend/pet-feeder-backend/src/feeders/feeders.service.ts
+++ b/backend/pet-feeder-backend/src/feeders/feeders.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateFeederDto } from './dto/create-feeder.dto';
+import { ApplyFeederDto } from './dto/apply-feeder.dto';
 import { UpdateFeederDto } from './dto/update-feeder.dto';
 import { Feeder } from './entities/feeder.entity';
 import { User } from '../users/entities/user.entity';
@@ -12,6 +13,23 @@ export class FeedersService {
     @InjectRepository(Feeder)
     private feedersRepository: Repository<Feeder>,
   ) {}
+
+  findByUserId(userId: number) {
+    return this.feedersRepository.findOne({ where: { user: { id: userId } } });
+  }
+
+  async apply(userId: number, dto: ApplyFeederDto) {
+    const existing = await this.findByUserId(userId);
+    if (existing) {
+      Object.assign(existing, dto, { status: 0, rejectReason: null });
+      return this.feedersRepository.save(existing);
+    }
+    const feeder = this.feedersRepository.create({
+      ...dto,
+      user: { id: userId } as User,
+    });
+    return this.feedersRepository.save(feeder);
+  }
 
   create(createFeederDto: CreateFeederDto) {
     const feeder = this.feedersRepository.create({

--- a/backend/pet-feeder-backend/src/service-orders/__tests__/service-orders.service.spec.ts
+++ b/backend/pet-feeder-backend/src/service-orders/__tests__/service-orders.service.spec.ts
@@ -7,8 +7,6 @@ import { Feeder } from '../../feeders/entities/feeder.entity';
 import { Order } from '../../orders/entities/order.entity';
 import { TrackingGateway } from '../../tracking/tracking.gateway';
 import { WxTemplateService } from '../../tracking/wx-template.service';
-import { Feeder } from '../../feeders/entities/feeder.entity';
-import { Order } from '../../orders/entities/order.entity';
 import { ServiceStatus } from '../status.enum';
 
 describe('ServiceOrdersService status flow', () => {

--- a/frontend/admin-vue/src/FeederAudit.vue
+++ b/frontend/admin-vue/src/FeederAudit.vue
@@ -9,10 +9,19 @@ const fetchFeeders = async () => {
   feeders.value = json.data || [];
 };
 const audit = async (id, approve) => {
-  await fetch(baseUrl + '/admin/feeders/audit', {
-    method: 'POST',
+  let reason = '';
+  if (!approve) {
+    const res = await ElMessageBox.prompt('请输入拒绝原因', '驳回', {
+      confirmButtonText: '确定',
+      cancelButtonText: '取消',
+    }).catch(() => null);
+    if (!res) return;
+    reason = res.value;
+  }
+  await fetch(baseUrl + `/admin/feeders/${id}/audit`, {
+    method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ feederId: id, approve }),
+    body: JSON.stringify({ approve, reason }),
   });
   fetchFeeders();
 };

--- a/frontend/miniapp/pages.json
+++ b/frontend/miniapp/pages.json
@@ -9,7 +9,9 @@
     {"path": "pages/orders/track", "style": {"navigationBarTitleText": "服务追踪"}},
     {"path": "pages/im/chat", "style": {"navigationBarTitleText": "聊天"}},
     {"path": "pages/user/profile", "style": {"navigationBarTitleText": "个人中心"}},
-    {"path": "pages/pay/result", "style": {"navigationBarTitleText": "支付结果"}}
+    {"path": "pages/pay/result", "style": {"navigationBarTitleText": "支付结果"}},
+    {"path": "pages/feeder/apply", "style": {"navigationBarTitleText": "喂养员申请"}},
+    {"path": "pages/feeder/status", "style": {"navigationBarTitleText": "审核状态"}}
   ],
   "globalStyle": {
     "navigationBarTitleText": "Pet Feeder",

--- a/frontend/miniapp/pages/feeder/apply.vue
+++ b/frontend/miniapp/pages/feeder/apply.vue
@@ -1,0 +1,33 @@
+<template>
+  <view class="container">
+    <input v-model="form.name" placeholder="姓名" />
+    <input v-model="form.phone" placeholder="手机号" />
+    <input v-model="form.idCard" placeholder="身份证号" />
+    <button @click="chooseAvatar">选择头像</button>
+    <image v-if="form.avatar" :src="form.avatar" style="width:100px;height:100px" />
+    <button type="primary" @click="submit">提交</button>
+  </view>
+</template>
+
+<script>
+import { request } from '@/utils/request'
+export default {
+  data() {
+    return { form: { name: '', phone: '', idCard: '', avatar: '' } }
+  },
+  methods: {
+    chooseAvatar() {
+      uni.chooseImage({ count: 1, success: res => { this.form.avatar = res.tempFilePaths[0] } })
+    },
+    submit() {
+      request({ url: '/feeder/apply', method: 'POST', data: this.form }).then(() => {
+        uni.redirectTo({ url: '/pages/feeder/status' })
+      })
+    }
+  }
+}
+</script>
+
+<style>
+.container { padding: 20rpx; }
+</style>

--- a/frontend/miniapp/pages/feeder/status.vue
+++ b/frontend/miniapp/pages/feeder/status.vue
@@ -1,0 +1,34 @@
+<template>
+  <view class="container">
+    <view>状态：{{ statusText }}</view>
+    <view v-if="profile && profile.status === 2">原因：{{ profile.rejectReason }}</view>
+    <button v-if="profile && profile.status === 2" @click="reapply">重新申请</button>
+  </view>
+</template>
+
+<script>
+import { request } from '@/utils/request'
+export default {
+  data() {
+    return { profile: null }
+  },
+  onShow() {
+    request({ url: '/feeder/profile' }).then(res => { this.profile = res })
+  },
+  computed: {
+    statusText() {
+      const s = this.profile ? this.profile.status : 0
+      return ['待审核', '通过', '驳回'][s]
+    }
+  },
+  methods: {
+    reapply() {
+      uni.redirectTo({ url: '/pages/feeder/apply' })
+    }
+  }
+}
+</script>
+
+<style>
+.container { padding: 20rpx; }
+</style>


### PR DESCRIPTION
## Summary
- fix duplicate imports in service order tests
- add feeder apply/profile endpoints
- include reject reason on feeder audit
- add feeder application pages in miniapp and update admin UI

## Testing
- `cd backend/pet-feeder-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a66d01bf0832085b192fb68928778