### PR TITLE
Implement admin authentication and management endpoints

### DIFF
--- a/backend/pet-feeder-backend/package-lock.json
+++ b/backend/pet-feeder-backend/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/typeorm": "^11.0.0",
         "@nestjs/websockets": "^11.0.0",
         "axios": "^1.10.0",
+        "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "mysql2": "^3.9.0",
@@ -5263,6 +5264,12 @@
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/bin-version": {
       "version": "6.0.0",

--- a/backend/pet-feeder-backend/package.json
+++ b/backend/pet-feeder-backend/package.json
@@ -28,8 +28,9 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.1.4",
     "@nestjs/typeorm": "^11.0.0",
-    "@nestjs/websockets": "^11.1.4",
+    "@nestjs/websockets": "^11.0.0",
     "axios": "^1.10.0",
+    "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "mysql2": "^3.9.0",
@@ -37,9 +38,8 @@
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.25",
-    "@nestjs/websockets": "^11.0.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "typeorm": "^0.3.25"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/pet-feeder-backend/src/admin/admin.controller.ts
+++ b/backend/pet-feeder-backend/src/admin/admin.controller.ts
@@ -1,46 +1,100 @@
-import { Body, Controller, Get, Post, Patch, Param, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Patch, Param, Query, UseGuards, Req, UnauthorizedException } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Roles } from '../common/decorators/roles.decorator';
 import { RolesGuard } from '../common/guards/roles.guard';
-import { AdminRole } from './admin-role.enum';
 import { AdminService } from './admin.service';
 import { AuditFeederDto } from './dto/audit-feeder.dto';
 import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
+import { AdminLoginDto } from './dto/admin-login.dto';
+import { HandleComplaintDto } from './dto/handle-complaint.dto';
 
 @Controller('admin')
-@UseGuards(JwtAuthGuard, RolesGuard)
 export class AdminController {
   constructor(private readonly service: AdminService) {}
 
+  @Post('login')
+  async login(@Body() dto: AdminLoginDto) {
+    const res = await this.service.login(dto.username, dto.password);
+    if (!res) throw new UnauthorizedException();
+    return res;
+  }
+
+  @Get('profile')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('super', 'operator')
+  profile(@Req() req) {
+    return this.service.profile(req.user.userId);
+  }
+
   @Get('feeders')
-  @Roles('admin')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('super', 'operator')
   getFeeders(@Query('status') status?: string) {
     const s = status ? parseInt(status, 10) : undefined;
     return this.service.findFeeders(s);
   }
 
   @Post('feeders/audit')
-  @Roles('admin')
-  auditFeeder(@Body() dto: AuditFeederDto) {
-    return this.service.auditFeeder(dto);
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('super', 'operator')
+  auditFeeder(@Req() req, @Body() dto: AuditFeederDto) {
+    return this.service.auditFeeder(dto, req.user.userId);
   }
 
   @Patch('feeders/:id/audit')
-  @Roles('admin')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('super', 'operator')
   auditFeederById(
     @Param('id') id: string,
     @Body() dto: Omit<AuditFeederDto, 'feederId'>,
+    @Req() req,
   ) {
-    return this.service.auditFeeder({
-      feederId: parseInt(id, 10),
-      approve: dto.approve,
-      reason: dto.reason,
-    });
+    return this.service.auditFeeder(
+      {
+        feederId: parseInt(id, 10),
+        approve: dto.approve,
+        reason: dto.reason,
+      },
+      req.user.userId,
+    );
   }
 
   @Post('orders/update-status')
-  @Roles('admin')
-  updateOrderStatus(@Body() dto: UpdateOrderStatusDto) {
-    return this.service.updateOrderStatus(dto);
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('super', 'operator')
+  updateOrderStatus(@Req() req, @Body() dto: UpdateOrderStatusDto) {
+    return this.service.updateOrderStatus(dto, req.user.userId);
+  }
+
+  @Get('complaints')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('super', 'operator')
+  getComplaints(@Query('status') status?: string) {
+    return this.service.listComplaints(status);
+  }
+
+  @Patch('complaints/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('super', 'operator')
+  handleComplaint(
+    @Param('id') id: string,
+    @Req() req,
+    @Body() dto: HandleComplaintDto,
+  ) {
+    return this.service.handleComplaint(Number(id), req.user.userId, dto);
+  }
+
+  @Get('feedback')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('super', 'operator')
+  getFeedback() {
+    return this.service.listFeedback();
+  }
+
+  @Get('logs')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('super', 'operator')
+  getLogs() {
+    return this.service.listLogs();
   }
 }

--- a/backend/pet-feeder-backend/src/admin/admin.module.ts
+++ b/backend/pet-feeder-backend/src/admin/admin.module.ts
@@ -1,15 +1,30 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule } from '@nestjs/jwt';
 import { Feeder } from '../feeders/entities/feeder.entity';
 import { Order } from '../orders/entities/order.entity';
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { AdminUser } from './entities/admin-user.entity';
 import { AdminOperationLog } from './entities/admin-operation-log.entity';
+import { Complaint } from '../complaints/entities/complaint.entity';
+import { Feedback } from '../feedback/entities/feedback.entity';
+import { loadConfig } from '../infrastructure/config';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Feeder, Order, AdminUser, AdminOperationLog]),
+    TypeOrmModule.forFeature([
+      Feeder,
+      Order,
+      AdminUser,
+      AdminOperationLog,
+      Complaint,
+      Feedback,
+    ]),
+    JwtModule.register({
+      secret: loadConfig().jwtSecret,
+      signOptions: { expiresIn: '1d' },
+    }),
   ],
   controllers: [AdminController],
   providers: [AdminService],

--- a/backend/pet-feeder-backend/src/admin/admin.service.ts
+++ b/backend/pet-feeder-backend/src/admin/admin.service.ts
@@ -1,12 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { JwtService } from '@nestjs/jwt';
 import { Repository } from 'typeorm';
+import * as bcrypt from 'bcryptjs';
 import { Feeder } from '../feeders/entities/feeder.entity';
 import { Order } from '../orders/entities/order.entity';
+import { Complaint } from '../complaints/entities/complaint.entity';
+import { Feedback } from '../feedback/entities/feedback.entity';
 import { AdminUser } from './entities/admin-user.entity';
+import { AdminOperationLog } from './entities/admin-operation-log.entity';
 import { AdminRole } from './admin-role.enum';
 import { AuditFeederDto } from './dto/audit-feeder.dto';
 import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
+import { HandleComplaintDto } from './dto/handle-complaint.dto';
 
 @Injectable()
 export class AdminService {
@@ -15,32 +21,101 @@ export class AdminService {
     private feedersRepository: Repository<Feeder>,
     @InjectRepository(Order)
     private ordersRepository: Repository<Order>,
+    @InjectRepository(Complaint)
+    private complaintsRepository: Repository<Complaint>,
+    @InjectRepository(Feedback)
+    private feedbackRepository: Repository<Feedback>,
     @InjectRepository(AdminUser)
     private adminRepository: Repository<AdminUser>,
+    @InjectRepository(AdminOperationLog)
+    private logRepository: Repository<AdminOperationLog>,
+    private jwtService: JwtService,
   ) {}
 
   async findFeeders(status?: number) {
     return this.feedersRepository.find({ where: status ? { status } : {} });
   }
 
-  async auditFeeder(dto: AuditFeederDto) {
+  async auditFeeder(dto: AuditFeederDto, adminId: number) {
     const status = dto.approve ? 1 : 2;
-    return this.feedersRepository.update(dto.feederId, {
+    const result = await this.feedersRepository.update(dto.feederId, {
       status,
-      rejectReason: dto.approve ? null : dto.reason,
+      rejectReason: dto.approve ? undefined : dto.reason,
     });
+    await this.logOperation(dto.feederId, 'feeder', `audit:${dto.approve}`, dto.reason, adminId);
+    return result;
   }
 
-  async updateOrderStatus(dto: UpdateOrderStatusDto) {
-    return this.ordersRepository.update(dto.orderId, { status: dto.status });
+  async updateOrderStatus(dto: UpdateOrderStatusDto, adminId: number) {
+    const res = await this.ordersRepository.update(dto.orderId, { status: dto.status });
+    await this.logOperation(dto.orderId, 'order', `status:${dto.status}`, undefined, adminId);
+    return res;
   }
 
   async createAdminUser(username: string, password: string, role: AdminRole) {
-    const user = this.adminRepository.create({ username, password, role });
+    const hash = await bcrypt.hash(password, 10);
+    const user = this.adminRepository.create({ username, password: hash, role });
     return this.adminRepository.save(user);
   }
 
   async findByUsername(username: string) {
     return this.adminRepository.findOne({ where: { username } });
+  }
+
+  async validateUser(username: string, password: string) {
+    const user = await this.findByUsername(username);
+    if (!user) return null;
+    const match = await bcrypt.compare(password, user.password);
+    if (!match || user.status === 0) return null;
+    return user;
+  }
+
+  async login(username: string, password: string) {
+    const user = await this.validateUser(username, password);
+    if (!user) return null;
+    const payload = { sub: user.id, role: user.role };
+    const token = await this.jwtService.signAsync(payload);
+    return { token };
+  }
+
+  async profile(userId: number) {
+    return this.adminRepository.findOne({ where: { id: userId } });
+  }
+
+  async listComplaints(status?: string) {
+    return this.complaintsRepository.find({
+      where: status ? { status } : {},
+      relations: ['user', 'handledBy', 'relatedOrder'],
+    });
+  }
+
+  async handleComplaint(id: number, adminId: number, dto: HandleComplaintDto) {
+    const result = await this.complaintsRepository.update(id, {
+      status: dto.status,
+      result: dto.result,
+      handledBy: { id: adminId } as AdminUser,
+      handledAt: new Date(),
+    });
+    await this.logOperation(id, 'complaint', `update:${dto.status}`, undefined, adminId);
+    return result;
+  }
+
+  async listFeedback() {
+    return this.feedbackRepository.find({ relations: ['user', 'order'] });
+  }
+
+  async listLogs() {
+    return this.logRepository.find({ relations: ['user'], order: { id: 'DESC' } });
+  }
+
+  private async logOperation(targetId: number, targetType: string, action: string, detail?: string, userId?: number) {
+    const log = this.logRepository.create({
+      user: { id: userId || 0 } as any,
+      targetId,
+      targetType,
+      action,
+      detail,
+    });
+    await this.logRepository.save(log);
   }
 }

--- a/backend/pet-feeder-backend/src/admin/dto/handle-complaint.dto.ts
+++ b/backend/pet-feeder-backend/src/admin/dto/handle-complaint.dto.ts
@@ -1,0 +1,4 @@
+export class HandleComplaintDto {
+  status: string;
+  result: string;
+}

--- a/backend/pet-feeder-backend/src/feedback/feedback.service.ts
+++ b/backend/pet-feeder-backend/src/feedback/feedback.service.ts
@@ -25,4 +25,8 @@ export class FeedbackService {
     });
     return this.feedbacks.save(entity);
   }
+
+  findAll() {
+    return this.feedbacks.find({ relations: ['user', 'order'] });
+  }
 }


### PR DESCRIPTION
## Summary
- add `bcryptjs` dependency
- implement admin login and profile endpoints
- add complaint handling, feedback list and log list APIs
- log admin operations in service
- expose new HandleComplaintDto

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a7aba0d54832097d8e4dbd6d6c58f