### PR TITLE
Add WeChat pay integration

### DIFF
--- a/backend/pet-feeder-backend/config/development.json
+++ b/backend/pet-feeder-backend/config/development.json
@@ -3,6 +3,7 @@
   "jwtSecret": "3KMV+fuV54n1V7JmT6pAxKX+1Lh4zUj3Tx6Dw5TZtZ8dG9pK6UvXRA==",
   "frontendDomain": "http://localhost:8080",
   "wechat": { "appid": "", "secret": "" },
+  "wechatPay": { "appid": "", "mchid": "", "key": "", "notifyUrl": "" },
   "redis": { "host": "localhost", "port": 6379 },
   "kafka": { "brokers": ["localhost:9092"] },
   "db": {

--- a/backend/pet-feeder-backend/config/production.json
+++ b/backend/pet-feeder-backend/config/production.json
@@ -3,6 +3,7 @@
   "jwtSecret": "change-me",
   "frontendDomain": "https://example.com",
   "wechat": { "appid": "", "secret": "" },
+  "wechatPay": { "appid": "", "mchid": "", "key": "", "notifyUrl": "" },
   "redis": { "host": "redis", "port": 6379 },
   "kafka": { "brokers": ["kafka:9092"] },
   "db": {

--- a/backend/pet-feeder-backend/src/infrastructure/config.service.ts
+++ b/backend/pet-feeder-backend/src/infrastructure/config.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { loadConfig } from './config';
+
+@Injectable()
+export class ConfigService {
+  private readonly cfg = loadConfig();
+
+  get wechatPay() {
+    return (this.cfg as any).wechatPay || {};
+  }
+}

--- a/backend/pet-feeder-backend/src/infrastructure/config.ts
+++ b/backend/pet-feeder-backend/src/infrastructure/config.ts
@@ -14,6 +14,7 @@ export interface AppConfig {
   jwtSecret: string;
   frontendDomain: string;
   wechat: { appid: string; secret: string };
+  wechatPay?: { appid: string; mchid: string; key: string; notifyUrl: string };
   redis: { host: string; port: number };
   kafka: { brokers: string[] };
   db: DbConfig;
@@ -25,6 +26,7 @@ export function loadConfig(): AppConfig {
     jwtSecret: 'secret',
     frontendDomain: 'http://localhost:8080',
     wechat: { appid: '', secret: '' },
+    wechatPay: { appid: '', mchid: '', key: '', notifyUrl: '' },
     redis: { host: 'localhost', port: 6379 },
     kafka: { brokers: ['localhost:9092'] },
     db: {

--- a/backend/pet-feeder-backend/src/orders/__tests__/payment.service.spec.ts
+++ b/backend/pet-feeder-backend/src/orders/__tests__/payment.service.spec.ts
@@ -1,0 +1,44 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { OrdersService } from '../orders.service';
+import { Order } from '../entities/order.entity';
+import { Feeder } from '../../feeders/entities/feeder.entity';
+import { WxPayService } from '../wx-pay.service';
+import { PayOrderDto } from '../dto/pay-order.dto';
+
+describe('OrdersService payment', () => {
+  let service: OrdersService;
+  const orderRepo = { findOne: jest.fn(), update: jest.fn() } as unknown as Repository<Order>;
+  const feederRepo = {} as Repository<Feeder>;
+  const wxPay: any = { createJsapiTransaction: jest.fn(), handleNotify: jest.fn() };
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        OrdersService,
+        { provide: getRepositoryToken(Order), useValue: orderRepo },
+        { provide: getRepositoryToken(Feeder), useValue: feederRepo },
+        { provide: WxPayService, useValue: wxPay },
+      ],
+    }).compile();
+    service = module.get(OrdersService);
+    jest.clearAllMocks();
+  });
+
+  it('creates prepay', async () => {
+    orderRepo.findOne = jest.fn().mockResolvedValue({ id: 1 });
+    wxPay.createJsapiTransaction.mockResolvedValue({ prepay_id: 'p' });
+
+    const res = await service.createPrepay({ orderId: '1', openid: 'o' });
+    expect(wxPay.createJsapiTransaction).toBeCalledWith('o', 1, '1');
+    expect(res).toEqual({ prepay_id: 'p' });
+  });
+
+  it('updates status on notify', async () => {
+    wxPay.handleNotify.mockResolvedValue({ out_trade_no: '2' });
+    orderRepo.update = jest.fn().mockResolvedValue({});
+    await service.handlePayNotify({}, {});
+    expect(orderRepo.update).toBeCalledWith(2, { status: 'paid' });
+  });
+});

--- a/backend/pet-feeder-backend/src/orders/dto/pay-order.dto.ts
+++ b/backend/pet-feeder-backend/src/orders/dto/pay-order.dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class PayOrderDto {
+  @IsString()
+  orderId: string;
+
+  @IsString()
+  openid: string;
+}

--- a/backend/pet-feeder-backend/src/orders/orders.controller.ts
+++ b/backend/pet-feeder-backend/src/orders/orders.controller.ts
@@ -8,6 +8,8 @@ import {
   Delete,
   Req,
   UseGuards,
+  Headers,
+  Header,
 } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
@@ -15,6 +17,7 @@ import { UpdateOrderDto } from './dto/update-order.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Roles } from '../common/decorators/roles.decorator';
+import { PayOrderDto } from './dto/pay-order.dto';
 
 @Controller('orders')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -52,6 +55,20 @@ export class OrdersController {
   @Roles('user', 'operator', 'super')
   update(@Param('id') id: string, @Body() updateOrderDto: UpdateOrderDto) {
     return this.ordersService.update(+id, updateOrderDto);
+  }
+
+  @Post('pay')
+  @Roles('user')
+  pay(@Body() dto: PayOrderDto) {
+    return this.ordersService.createPrepay(dto);
+  }
+
+  @Post('pay/notify')
+  @UseGuards()
+  @Header('Content-Type', 'text/xml')
+  async payNotify(@Req() req, @Headers() headers: Record<string, any>) {
+    await this.ordersService.handlePayNotify(req.body, headers);
+    return '<xml><return_code>SUCCESS</return_code></xml>';
   }
 
   @Delete(':id')

--- a/backend/pet-feeder-backend/src/orders/orders.module.ts
+++ b/backend/pet-feeder-backend/src/orders/orders.module.ts
@@ -4,10 +4,12 @@ import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
 import { Order } from './entities/order.entity';
 import { Feeder } from '../feeders/entities/feeder.entity';
+import { WxPayService } from './wx-pay.service';
+import { ConfigService } from '../infrastructure/config.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Order, Feeder])],
   controllers: [OrdersController],
-  providers: [OrdersService],
+  providers: [OrdersService, WxPayService, ConfigService],
 })
 export class OrdersModule {}

--- a/backend/pet-feeder-backend/src/orders/wx-pay.service.ts
+++ b/backend/pet-feeder-backend/src/orders/wx-pay.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '../infrastructure/config.service';
+import { randomBytes } from 'crypto';
+
+export interface JsapiPayParams {
+  timeStamp: string;
+  nonceStr: string;
+  package: string;
+  signType: string;
+  paySign: string;
+}
+
+@Injectable()
+export class WxPayService {
+  constructor(private readonly config: ConfigService) {}
+
+  async createJsapiTransaction(
+    openid: string,
+    amount: number,
+    outTradeNo: string,
+  ): Promise<JsapiPayParams> {
+    // Placeholder implementation. In production this should call wechatpay SDK.
+    const prepayId = 'test_prepay_id';
+    return this.sign(prepayId);
+  }
+
+  async handleNotify(body: any, headers: Record<string, any>): Promise<{ out_trade_no: string }> {
+    // Placeholder to decode and verify notify data.
+    return { out_trade_no: body.out_trade_no };
+  }
+
+  private sign(prepayId: string): JsapiPayParams {
+    const timeStamp = Math.floor(Date.now() / 1000).toString();
+    const nonceStr = randomBytes(16).toString('hex');
+    return {
+      timeStamp,
+      nonceStr,
+      package: `prepay_id=${prepayId}`,
+      signType: 'RSA',
+      paySign: 'sign',
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add ConfigService wrapper for wechat pay options
- implement WxPayService stub
- add pay endpoints and logic in order module
- extend config with wechatPay settings
- test order payment service

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687af6bb9b94832082f04b0bee2631f9