### PR TITLE
Improve backend error handling

### DIFF
--- a/backend/pet-feeder-backend/src/common/exceptions/business.exception.ts
+++ b/backend/pet-feeder-backend/src/common/exceptions/business.exception.ts
@@ -1,0 +1,11 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/**
+ * Custom business exception for domain errors.
+ * Allows specifying an application-level error code and message.
+ */
+export class BusinessException extends HttpException {
+  constructor(public code: number, message: string, status = HttpStatus.BAD_REQUEST) {
+    super(message, status);
+  }
+}

--- a/backend/pet-feeder-backend/src/common/filters/http-exception.filter.ts
+++ b/backend/pet-feeder-backend/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,52 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { BusinessException } from '../exceptions/business.exception';
+
+/**
+ * Global HTTP exception filter that formats all error responses consistently.
+ */
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const status = exception instanceof HttpException
+      ? exception.getStatus()
+      : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    let code = 1;
+    let message = 'Internal server error';
+
+    if (exception instanceof BusinessException) {
+      code = exception.code;
+      message = exception.message;
+    } else if (exception instanceof HttpException) {
+      const res = exception.getResponse();
+      if (typeof res === 'string') {
+        message = res;
+      } else if (typeof res === 'object' && (res as any).message) {
+        message = Array.isArray((res as any).message)
+          ? (res as any).message.join(', ')
+          : (res as any).message;
+      } else {
+        message = exception.message;
+      }
+    }
+
+    this.logger.error(
+      `Error ${status} on ${request.method} ${request.url}: ${message}`,
+      (exception as any)?.stack,
+    );
+
+    response.status(status).json({
+      code,
+      message,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/backend/pet-feeder-backend/src/common/pipes/validation-exception.factory.ts
+++ b/backend/pet-feeder-backend/src/common/pipes/validation-exception.factory.ts
@@ -1,0 +1,13 @@
+import { ValidationError } from 'class-validator';
+import { BusinessException } from '../exceptions/business.exception';
+
+/**
+ * Builds a BusinessException from validation errors so the global filter
+ * can format the response.
+ */
+export function validationExceptionFactory(errors: ValidationError[]) {
+  const messages = errors
+    .map((e) => Object.values(e.constraints || {}).join(', '))
+    .join('; ');
+  return new BusinessException(1001, messages || 'Validation failed');
+}

--- a/backend/pet-feeder-backend/src/main.ts
+++ b/backend/pet-feeder-backend/src/main.ts
@@ -5,6 +5,8 @@ import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { loadConfig } from './infrastructure/config';
 import { ValidationPipe } from '@nestjs/common';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { validationExceptionFactory } from './common/pipes/validation-exception.factory';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -12,7 +14,14 @@ async function bootstrap() {
     new LoggingInterceptor(),
     new ResponseInterceptor(),
   );
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      exceptionFactory: validationExceptionFactory,
+    }),
+  );
 
   const config = new DocumentBuilder()
     .setTitle('Pet Feeder API')

--- a/backend/pet-feeder-backend/src/orders/orders.service.ts
+++ b/backend/pet-feeder-backend/src/orders/orders.service.ts
@@ -1,8 +1,5 @@
-import {
-  Injectable,
-  BadRequestException,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, HttpStatus } from '@nestjs/common';
+import { BusinessException } from '../common/exceptions/business.exception';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateOrderDto } from './dto/create-order.dto';
@@ -33,7 +30,7 @@ export class OrdersService {
           where: { status: 1, isBlacklist: 0 },
         });
         if (available.length === 0) {
-          throw new BadRequestException('NO_FEEDER');
+          throw new BusinessException(2001, 'NO_FEEDER');
         }
         feederId =
           available[Math.floor(Math.random() * available.length)].id;
@@ -81,7 +78,7 @@ export class OrdersService {
     const order = await this.ordersRepository.findOne({
       where: { id: parseInt(dto.orderId, 10) },
     });
-    if (!order) throw new NotFoundException('ORDER_NOT_FOUND');
+    if (!order) throw new BusinessException(2002, 'ORDER_NOT_FOUND', HttpStatus.NOT_FOUND);
     return this.wxPay.createJsapiTransaction(dto.openid, 1, dto.orderId);
   }
 

--- a/backend/pet-feeder-backend/src/service-orders/service-orders.service.ts
+++ b/backend/pet-feeder-backend/src/service-orders/service-orders.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, ConflictException, ForbiddenException } from '@nestjs/common';
+import { Injectable, HttpStatus } from '@nestjs/common';
+import { BusinessException } from '../common/exceptions/business.exception';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, QueryFailedError } from 'typeorm';
 import { ServiceOrder } from './entities/service-order.entity';
@@ -27,13 +28,13 @@ export class ServiceOrdersService {
   async create(dto: CreateServiceOrderDto) {
     const feeder = await this.feeders.findOne({ where: { id: dto.feederId } });
     if (feeder?.isBlacklist) {
-      throw new ForbiddenException('BLACKLIST');
+      throw new BusinessException(3001, 'BLACKLIST', HttpStatus.FORBIDDEN);
     }
     const existing = await this.repository.findOne({
       where: { order: { id: dto.orderId } },
     });
     if (existing) {
-      throw new ConflictException('ORDER_TAKEN');
+      throw new BusinessException(3002, 'ORDER_TAKEN', HttpStatus.CONFLICT);
     }
 
     const entity = this.repository.create({
@@ -47,7 +48,7 @@ export class ServiceOrdersService {
       return saved;
     } catch (err) {
       if (err instanceof QueryFailedError) {
-        throw new ConflictException('ORDER_TAKEN');
+        throw new BusinessException(3002, 'ORDER_TAKEN', HttpStatus.CONFLICT);
       }
       throw err;
     }


### PR DESCRIPTION
## Summary
- create global HttpExceptionFilter
- add BusinessException for service layer errors
- unify validation error handling with ValidationExceptionFactory
- register filter and pipe in `main.ts`
- refactor order & service order services to use BusinessException

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687afb44c84083208f8e5b1c6db1f39a