### PR TITLE
Implement pet service booking flow

### DIFF
--- a/backend/pet-feeder-backend/src/app.module.ts
+++ b/backend/pet-feeder-backend/src/app.module.ts
@@ -15,6 +15,8 @@ import { EvaluationsModule } from './evaluations/evaluations.module';
 import { FeedbackModule } from './feedback/feedback.module';
 import { ComplaintsModule } from './complaints/complaints.module';
 import { FeederOrdersModule } from './feeder-orders/feeder-orders.module';
+import { ServiceTypesModule } from './service-types/service-types.module';
+import { ReserveOrdersModule } from './reserve-orders/reserve-orders.module';
 
 @Module({
   imports: [
@@ -39,6 +41,8 @@ import { FeederOrdersModule } from './feeder-orders/feeder-orders.module';
     OrdersModule,
     FeedersModule,
     ServiceOrdersModule,
+    ServiceTypesModule,
+    ReserveOrdersModule,
     TrackingModule,
     AuthModule,
     AdminModule,

--- a/backend/pet-feeder-backend/src/database/schema.sql
+++ b/backend/pet-feeder-backend/src/database/schema.sql
@@ -171,3 +171,40 @@ CREATE TABLE orders (
   FOREIGN KEY (petId) REFERENCES pets(id),
   FOREIGN KEY (feederId) REFERENCES feeders(id)
 );
+
+-- service_types table
+CREATE TABLE service_types (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(50) NOT NULL,
+  price DECIMAL(10,2) NOT NULL,
+  member_price DECIMAL(10,2) NOT NULL,
+  description VARCHAR(255) NULL,
+  supported_species VARCHAR(50) NULL,
+  cover_url VARCHAR(255) NULL
+);
+
+-- reserve_orders table
+CREATE TABLE reserve_orders (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  userId INT NOT NULL,
+  reserveTime DATETIME NOT NULL,
+  address VARCHAR(200) NOT NULL,
+  remark TEXT NULL,
+  totalAmount DECIMAL(10,2) NOT NULL,
+  status VARCHAR(20) DEFAULT 'pending',
+  create_time DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (userId) REFERENCES users(id)
+);
+
+-- reserve_order_items table
+CREATE TABLE reserve_order_items (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  orderId INT NOT NULL,
+  serviceId INT NOT NULL,
+  petId INT NOT NULL,
+  price DECIMAL(10,2) NOT NULL,
+  serviceName VARCHAR(50) NOT NULL,
+  FOREIGN KEY (orderId) REFERENCES reserve_orders(id),
+  FOREIGN KEY (serviceId) REFERENCES service_types(id),
+  FOREIGN KEY (petId) REFERENCES pets(id)
+);

--- a/backend/pet-feeder-backend/src/reserve-orders/__tests__/reserve-orders.service.spec.ts
+++ b/backend/pet-feeder-backend/src/reserve-orders/__tests__/reserve-orders.service.spec.ts
@@ -1,0 +1,54 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ReserveOrdersService } from '../reserve-orders.service';
+import { OrderEntity } from '../entities/order.entity';
+import { OrderServiceItem } from '../entities/order-service-item.entity';
+import { ServiceType } from '../../service-types/entities/service-type.entity';
+import { Pet } from '../../pets/entities/pet.entity';
+
+const createRepo = () => ({ create: jest.fn(), save: jest.fn(), findOne: jest.fn(), find: jest.fn() });
+
+describe('ReserveOrdersService create', () => {
+  let service: ReserveOrdersService;
+  const orderRepo = createRepo() as unknown as Repository<OrderEntity>;
+  const itemRepo = createRepo() as unknown as Repository<OrderServiceItem>;
+  const serviceRepo = createRepo() as unknown as Repository<ServiceType>;
+  const petRepo = createRepo() as unknown as Repository<Pet>;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        ReserveOrdersService,
+        { provide: getRepositoryToken(OrderEntity), useValue: orderRepo },
+        { provide: getRepositoryToken(OrderServiceItem), useValue: itemRepo },
+        { provide: getRepositoryToken(ServiceType), useValue: serviceRepo },
+        { provide: getRepositoryToken(Pet), useValue: petRepo },
+      ],
+    }).compile();
+    service = module.get(ReserveOrdersService);
+    jest.clearAllMocks();
+  });
+
+  it('calculates total', async () => {
+    serviceRepo.findOne = jest.fn().mockResolvedValue({ id: 1, name: 'wash', price: 10 });
+    petRepo.findOne = jest.fn().mockResolvedValue({ id: 2, user: { id: 1 } });
+    orderRepo.manager = {
+      transaction: async (cb: any) => cb({
+        getRepository: () => orderRepo,
+      }),
+    } as any;
+    orderRepo.create = jest.fn().mockReturnValue({});
+    orderRepo.save = jest.fn().mockResolvedValue({ id: 1, totalAmount: 10 });
+
+    const res = await service.create(
+      {
+        reserveTime: new Date(Date.now() + 1000).toISOString() as any,
+        address: 'a',
+        items: [{ serviceId: 1, petId: 2 }],
+      },
+      1,
+    );
+    expect(res.totalAmount).toBe(10);
+  });
+});

--- a/backend/pet-feeder-backend/src/reserve-orders/dto/create-order.dto.ts
+++ b/backend/pet-feeder-backend/src/reserve-orders/dto/create-order.dto.ts
@@ -1,0 +1,12 @@
+export interface CreateOrderItemDto {
+  serviceId: number;
+  petId: number;
+}
+
+export class CreateReserveOrderDto {
+  userId?: number;
+  reserveTime: Date;
+  address: string;
+  remark?: string;
+  items: CreateOrderItemDto[];
+}

--- a/backend/pet-feeder-backend/src/reserve-orders/entities/order-service-item.entity.ts
+++ b/backend/pet-feeder-backend/src/reserve-orders/entities/order-service-item.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Pet } from '../../pets/entities/pet.entity';
+import { ServiceType } from '../../service-types/entities/service-type.entity';
+import { OrderEntity } from './order.entity';
+
+@Entity('reserve_order_items')
+export class OrderServiceItem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => OrderEntity, (order) => order.items)
+  order: OrderEntity;
+
+  @ManyToOne(() => ServiceType)
+  service: ServiceType;
+
+  @ManyToOne(() => Pet)
+  pet: Pet;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  price: number;
+
+  @Column({ length: 50 })
+  serviceName: string;
+}

--- a/backend/pet-feeder-backend/src/reserve-orders/entities/order.entity.ts
+++ b/backend/pet-feeder-backend/src/reserve-orders/entities/order.entity.ts
@@ -1,0 +1,35 @@
+import { Column, Entity, CreateDateColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { OrderServiceItem } from './order-service-item.entity';
+
+@Entity('reserve_orders')
+export class OrderEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User)
+  user: User;
+
+  @Column('datetime')
+  reserveTime: Date;
+
+  @Column({ length: 200 })
+  address: string;
+
+  @Column({ type: 'text', nullable: true })
+  remark?: string;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  totalAmount: number;
+
+  @Column({ length: 20, default: 'pending' })
+  status: string;
+
+  @CreateDateColumn({ name: 'create_time' })
+  createTime: Date;
+
+  @OneToMany(() => OrderServiceItem, (item) => item.order, {
+    cascade: true,
+  })
+  items: OrderServiceItem[];
+}

--- a/backend/pet-feeder-backend/src/reserve-orders/reserve-orders.controller.ts
+++ b/backend/pet-feeder-backend/src/reserve-orders/reserve-orders.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Post, Get, Body, Req, UseGuards, Param } from '@nestjs/common';
+import { ReserveOrdersService } from './reserve-orders.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { CreateReserveOrderDto } from './dto/create-order.dto';
+
+@Controller('reserve-orders')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ReserveOrdersController {
+  constructor(private readonly service: ReserveOrdersService) {}
+
+  @Post()
+  @Roles('user')
+  create(@Req() req, @Body() dto: CreateReserveOrderDto) {
+    const userId = dto.userId || req.user.userId;
+    return this.service.create(dto, userId);
+  }
+
+  @Get()
+  @Roles('user')
+  findMine(@Req() req) {
+    return this.service.findByUser(req.user.userId);
+  }
+
+  @Get(':id')
+  @Roles('user')
+  findOne(@Param('id') id: string, @Req() req) {
+    return this.service.findOne(+id, req.user.userId);
+  }
+}

--- a/backend/pet-feeder-backend/src/reserve-orders/reserve-orders.module.ts
+++ b/backend/pet-feeder-backend/src/reserve-orders/reserve-orders.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ReserveOrdersService } from './reserve-orders.service';
+import { ReserveOrdersController } from './reserve-orders.controller';
+import { OrderEntity } from './entities/order.entity';
+import { OrderServiceItem } from './entities/order-service-item.entity';
+import { ServiceType } from '../service-types/entities/service-type.entity';
+import { Pet } from '../pets/entities/pet.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([OrderEntity, OrderServiceItem, ServiceType, Pet]),
+  ],
+  controllers: [ReserveOrdersController],
+  providers: [ReserveOrdersService],
+})
+export class ReserveOrdersModule {}

--- a/backend/pet-feeder-backend/src/reserve-orders/reserve-orders.service.ts
+++ b/backend/pet-feeder-backend/src/reserve-orders/reserve-orders.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateReserveOrderDto } from './dto/create-order.dto';
+import { OrderEntity } from './entities/order.entity';
+import { OrderServiceItem } from './entities/order-service-item.entity';
+import { ServiceType } from '../service-types/entities/service-type.entity';
+import { Pet } from '../pets/entities/pet.entity';
+
+@Injectable()
+export class ReserveOrdersService {
+  constructor(
+    @InjectRepository(OrderEntity)
+    private ordersRepo: Repository<OrderEntity>,
+    @InjectRepository(OrderServiceItem)
+    private itemsRepo: Repository<OrderServiceItem>,
+    @InjectRepository(ServiceType)
+    private serviceRepo: Repository<ServiceType>,
+    @InjectRepository(Pet)
+    private petRepo: Repository<Pet>,
+  ) {}
+
+  async create(dto: CreateReserveOrderDto, userId: number) {
+    return this.ordersRepo.manager.transaction(async (manager) => {
+      const orderRepo = manager.getRepository(OrderEntity);
+      const itemRepo = manager.getRepository(OrderServiceItem);
+      const serviceRepo = manager.getRepository(ServiceType);
+      const petRepo = manager.getRepository(Pet);
+
+      if (new Date(dto.reserveTime) <= new Date()) {
+        throw new BadRequestException('reserveTime must be future');
+      }
+
+      const items: OrderServiceItem[] = [];
+      let total = 0;
+      for (const it of dto.items) {
+        const service = await serviceRepo.findOne({ where: { id: it.serviceId } });
+        if (!service) throw new BadRequestException('invalid service');
+        const pet = await petRepo.findOne({
+          where: { id: it.petId, user: { id: userId } },
+          relations: ['user'],
+        });
+        if (!pet) throw new BadRequestException('invalid pet');
+        total += Number(service.price);
+        const item = itemRepo.create({
+          service,
+          pet,
+          price: Number(service.price),
+          serviceName: service.name,
+        });
+        items.push(item);
+      }
+
+      const order = orderRepo.create({
+        user: { id: userId } as any,
+        reserveTime: dto.reserveTime,
+        address: dto.address,
+        remark: dto.remark,
+        totalAmount: total,
+        status: 'pending',
+        items,
+      });
+      return orderRepo.save(order);
+    });
+  }
+
+  findByUser(userId: number) {
+    return this.ordersRepo.find({
+      where: { user: { id: userId } },
+      relations: ['items', 'items.pet', 'items.service'],
+      order: { id: 'DESC' },
+    });
+  }
+
+  findOne(id: number, userId: number) {
+    return this.ordersRepo.findOne({
+      where: { id, user: { id: userId } },
+      relations: ['items', 'items.pet', 'items.service'],
+    });
+  }
+}

--- a/backend/pet-feeder-backend/src/service-types/dto/create-service-type.dto.ts
+++ b/backend/pet-feeder-backend/src/service-types/dto/create-service-type.dto.ts
@@ -1,0 +1,8 @@
+export class CreateServiceTypeDto {
+  name: string;
+  price: number;
+  memberPrice: number;
+  description?: string;
+  supportedSpecies?: string;
+  coverUrl?: string;
+}

--- a/backend/pet-feeder-backend/src/service-types/dto/update-service-type.dto.ts
+++ b/backend/pet-feeder-backend/src/service-types/dto/update-service-type.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateServiceTypeDto } from './create-service-type.dto';
+
+export class UpdateServiceTypeDto extends PartialType(CreateServiceTypeDto) {}

--- a/backend/pet-feeder-backend/src/service-types/entities/service-type.entity.ts
+++ b/backend/pet-feeder-backend/src/service-types/entities/service-type.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('service_types')
+export class ServiceType {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 50 })
+  name: string;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  price: number;
+
+  @Column('decimal', { precision: 10, scale: 2, name: 'member_price' })
+  memberPrice: number;
+
+  @Column({ length: 255, nullable: true })
+  description?: string;
+
+  @Column({ name: 'supported_species', length: 50, nullable: true })
+  supportedSpecies?: string;
+
+  @Column({ name: 'cover_url', length: 255, nullable: true })
+  coverUrl?: string;
+}

--- a/backend/pet-feeder-backend/src/service-types/service-types.controller.ts
+++ b/backend/pet-feeder-backend/src/service-types/service-types.controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
+import { ServiceTypesService } from './service-types.service';
+import { CreateServiceTypeDto } from './dto/create-service-type.dto';
+import { UpdateServiceTypeDto } from './dto/update-service-type.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+
+@Controller('service-types')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ServiceTypesController {
+  constructor(private readonly serviceTypesService: ServiceTypesService) {}
+
+  @Post()
+  @Roles('operator', 'super')
+  create(@Body() dto: CreateServiceTypeDto) {
+    return this.serviceTypesService.create(dto);
+  }
+
+  @Get()
+  @Roles('user', 'operator', 'super')
+  findAll() {
+    return this.serviceTypesService.findAll();
+  }
+
+  @Get(':id')
+  @Roles('user', 'operator', 'super')
+  findOne(@Param('id') id: string) {
+    return this.serviceTypesService.findOne(+id);
+  }
+
+  @Patch(':id')
+  @Roles('operator', 'super')
+  update(@Param('id') id: string, @Body() dto: UpdateServiceTypeDto) {
+    return this.serviceTypesService.update(+id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('operator', 'super')
+  remove(@Param('id') id: string) {
+    return this.serviceTypesService.remove(+id);
+  }
+}

--- a/backend/pet-feeder-backend/src/service-types/service-types.module.ts
+++ b/backend/pet-feeder-backend/src/service-types/service-types.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ServiceTypesService } from './service-types.service';
+import { ServiceTypesController } from './service-types.controller';
+import { ServiceType } from './entities/service-type.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ServiceType])],
+  controllers: [ServiceTypesController],
+  providers: [ServiceTypesService],
+  exports: [ServiceTypesService],
+})
+export class ServiceTypesModule {}

--- a/backend/pet-feeder-backend/src/service-types/service-types.service.ts
+++ b/backend/pet-feeder-backend/src/service-types/service-types.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateServiceTypeDto } from './dto/create-service-type.dto';
+import { UpdateServiceTypeDto } from './dto/update-service-type.dto';
+import { ServiceType } from './entities/service-type.entity';
+
+@Injectable()
+export class ServiceTypesService {
+  constructor(
+    @InjectRepository(ServiceType)
+    private repo: Repository<ServiceType>,
+  ) {}
+
+  create(dto: CreateServiceTypeDto) {
+    const entity = this.repo.create(dto);
+    return this.repo.save(entity);
+  }
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  findOne(id: number) {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  update(id: number, dto: UpdateServiceTypeDto) {
+    return this.repo.update(id, dto);
+  }
+
+  remove(id: number) {
+    return this.repo.delete(id);
+  }
+}

--- a/frontend/miniapp/pages.json
+++ b/frontend/miniapp/pages.json
@@ -14,7 +14,11 @@
     {"path": "pages/user/profile", "style": {"navigationBarTitleText": "个人中心"}},
     {"path": "pages/pay/result", "style": {"navigationBarTitleText": "支付结果"}},
     {"path": "pages/feeder/apply", "style": {"navigationBarTitleText": "喂养员申请"}},
-    {"path": "pages/feeder/status", "style": {"navigationBarTitleText": "审核状态"}}
+    {"path": "pages/feeder/status", "style": {"navigationBarTitleText": "审核状态"}},
+    {"path": "pages/service/select", "style": {"navigationBarTitleText": "选择服务"}},
+    {"path": "pages/service/pet-bind", "style": {"navigationBarTitleText": "绑定宠物"}},
+    {"path": "pages/service/reserve", "style": {"navigationBarTitleText": "填写预约"}},
+    {"path": "pages/service/confirm", "style": {"navigationBarTitleText": "确认预约"}}
   ],
   "globalStyle": {
     "navigationBarTitleText": "Pet Feeder",

--- a/frontend/miniapp/pages/service/confirm.vue
+++ b/frontend/miniapp/pages/service/confirm.vue
@@ -1,0 +1,36 @@
+<template>
+  <view class="confirm">
+    <view v-for="it in data.items" :key="it.serviceId" class="row">
+      <text>{{ it.serviceName }} - {{ it.petName }}</text>
+    </view>
+    <view>预约时间：{{ data.reserveTime }}</view>
+    <view>地址：{{ data.address }}</view>
+    <view>备注：{{ data.remark }}</view>
+    <button type="primary" @click="submit">立即预约</button>
+  </view>
+</template>
+<script>
+import { request } from '@/utils/request'
+export default {
+  data() {
+    return { data: {}, total: 0 }
+  },
+  onLoad(q) {
+    this.data = JSON.parse(decodeURIComponent(q.data))
+  },
+  methods: {
+    submit() {
+      request({
+        url: '/reserve-orders',
+        method: 'POST',
+        data: this.data
+      }).then(res => {
+        uni.redirectTo({ url: '/pages/orders/detail?id=' + res.id })
+      })
+    }
+  }
+}
+</script>
+<style>
+.row { margin:20rpx 0; }
+</style>

--- a/frontend/miniapp/pages/service/pet-bind.vue
+++ b/frontend/miniapp/pages/service/pet-bind.vue
@@ -1,0 +1,58 @@
+<template>
+  <view class="pet-bind">
+    <view v-if="pets.length === 0">
+      <text>暂无宠物</text>
+      <button @click="goAdd">添加宠物</button>
+    </view>
+    <view v-else>
+      <view v-for="srv in services" :key="srv.id" class="bind-row">
+        <text>{{ srv.name }}</text>
+        <picker :range="pets" range-key="name" @change="e => select(srv.id, e.detail.value)">
+          <view>{{ pickText(srv.id) }}</view>
+        </picker>
+      </view>
+      <button type="primary" @click="next">下一步</button>
+    </view>
+  </view>
+</template>
+<script>
+import { request } from '@/utils/request'
+export default {
+  data() {
+    return { services: [], pets: [], map: {} }
+  },
+  onLoad(query) {
+    const ids = query.ids.split(',')
+    request({ url: '/service-types' }).then(res => {
+      this.services = res.filter(i => ids.includes(String(i.id)))
+    })
+  },
+  onShow() {
+    request({ url: '/pets' }).then(res => { this.pets = res })
+  },
+  methods: {
+    goAdd() { uni.navigateTo({ url: '/pages/pets/edit' }) },
+    select(id, idx) { this.$set(this.map, id, idx) },
+    pickText(id) {
+      const idx = this.map[id];
+      return idx >= 0 ? this.pets[idx].name : '选择宠物'
+    },
+    next() {
+      const items = this.services.map(s => ({
+        serviceId: s.id,
+        petId: this.pets[this.map[s.id]]?.id,
+        serviceName: s.name,
+        petName: this.pets[this.map[s.id]]?.name,
+      }))
+      if (items.some(i => !i.petId)) {
+        uni.showToast({ title: '请选择宠物', icon: 'none' })
+        return
+      }
+      uni.navigateTo({ url: '/pages/service/reserve?data=' + encodeURIComponent(JSON.stringify(items)) })
+    }
+  }
+}
+</script>
+<style>
+.bind-row { margin:20rpx 0; }
+</style>

--- a/frontend/miniapp/pages/service/reserve.vue
+++ b/frontend/miniapp/pages/service/reserve.vue
@@ -1,0 +1,41 @@
+<template>
+  <view class="reserve">
+    <view v-for="it in items" :key="it.serviceId" class="row">
+      <text>{{ it.serviceName }} - {{ it.petName }}</text>
+    </view>
+    <picker mode="datetime" @change="e => reserveTime = e.detail.value">
+      <view>{{ reserveTime || '选择时间' }}</view>
+    </picker>
+    <input v-model="address" placeholder="服务地址" />
+    <textarea v-model="remark" placeholder="备注" />
+    <button type="primary" @click="next">确认</button>
+  </view>
+</template>
+<script>
+export default {
+  data() {
+    return { items: [], reserveTime: '', address: '', remark: '' }
+  },
+  onLoad(q) {
+    this.items = JSON.parse(decodeURIComponent(q.data))
+  },
+  methods: {
+    next() {
+      if (!this.reserveTime || !this.address) {
+        uni.showToast({ title: '请填写完整', icon: 'none' })
+        return
+      }
+      const data = {
+        items: this.items.map(i => ({ serviceId: i.serviceId, petId: i.petId })),
+        reserveTime: this.reserveTime,
+        address: this.address,
+        remark: this.remark
+      }
+      uni.navigateTo({ url: '/pages/service/confirm?data=' + encodeURIComponent(JSON.stringify(data)) })
+    }
+  }
+}
+</script>
+<style>
+.row { margin:20rpx 0; }
+</style>

--- a/frontend/miniapp/pages/service/select.vue
+++ b/frontend/miniapp/pages/service/select.vue
@@ -1,0 +1,42 @@
+<template>
+  <view class="service-select">
+    <checkbox-group v-model="selected">
+      <label v-for="item in list" :key="item.id" class="service-item">
+        <image :src="item.coverUrl" class="cover" />
+        <view class="info">
+          <view class="name">{{ item.name }}</view>
+          <view class="price">￥{{ item.price }} / 会员￥{{ item.memberPrice }}</view>
+        <checkbox :value="String(item.id)" />
+        </view>
+      </label>
+    </checkbox-group>
+    <button type="primary" @click="next">下一步</button>
+  </view>
+</template>
+<script>
+import { request } from '@/utils/request'
+export default {
+  data() {
+    return { list: [], selected: [] }
+  },
+  onShow() {
+    request({ url: '/service-types' }).then(res => {
+      this.list = res
+    })
+  },
+  methods: {
+    next() {
+      if (!this.selected.length) {
+        uni.showToast({ title: '请选择服务', icon: 'none' })
+        return
+      }
+      uni.navigateTo({ url: '/pages/service/pet-bind?ids=' + this.selected.join(',') })
+    }
+  }
+}
+</script>
+<style>
+.service-item { margin: 20rpx 0; display:flex; }
+.cover { width:100rpx; height:100rpx; }
+.info { flex:1; margin-left:20rpx; }
+</style>


### PR DESCRIPTION
## Summary
- support service types CRUD
- add reserve orders with service items
- expose endpoints and wire modules
- update DB schema for new tables
- create miniapp pages for selecting services and booking
- cover reserve order service with unit test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b011df1ac832096b1169b0ef4ddbe