### PR TITLE
Add feeder schedule module and frontend page

### DIFF
--- a/backend/pet-feeder-backend/src/app.module.ts
+++ b/backend/pet-feeder-backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { EvaluationsModule } from './evaluations/evaluations.module';
 import { FeedbackModule } from './feedback/feedback.module';
 import { ComplaintsModule } from './complaints/complaints.module';
 import { FeederOrdersModule } from './feeder-orders/feeder-orders.module';
+import { FeederSchedulesModule } from './feeder-schedules/feeder-schedules.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { FeederOrdersModule } from './feeder-orders/feeder-orders.module';
     FeedbackModule,
     ComplaintsModule,
     FeederOrdersModule,
+    FeederSchedulesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/pet-feeder-backend/src/feeder-schedules/dto/batch-schedule.dto.ts
+++ b/backend/pet-feeder-backend/src/feeder-schedules/dto/batch-schedule.dto.ts
@@ -1,0 +1,13 @@
+import { Type } from 'class-transformer';
+import { IsArray, ValidateNested } from 'class-validator';
+import { ScheduleItemDto } from './schedule-item.dto';
+
+/**
+ * DTO for batch saving schedule items.
+ */
+export class BatchScheduleDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ScheduleItemDto)
+  items: ScheduleItemDto[];
+}

--- a/backend/pet-feeder-backend/src/feeder-schedules/dto/schedule-item.dto.ts
+++ b/backend/pet-feeder-backend/src/feeder-schedules/dto/schedule-item.dto.ts
@@ -1,0 +1,21 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+/**
+ * Single schedule time range DTO.
+ */
+export class ScheduleItemDto {
+  @IsInt()
+  @Min(0)
+  @Max(6)
+  weekday: number;
+
+  @IsString()
+  startTime: string;
+
+  @IsString()
+  endTime: string;
+
+  @IsOptional()
+  @IsInt()
+  enabled?: number;
+}

--- a/backend/pet-feeder-backend/src/feeder-schedules/entities/feeder-schedule.entity.ts
+++ b/backend/pet-feeder-backend/src/feeder-schedules/entities/feeder-schedule.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Feeder } from '../../feeders/entities/feeder.entity';
+
+/**
+ * FeederSchedule defines availability time ranges for a feeder.
+ */
+@Entity('feeder_schedules')
+export class FeederSchedule {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Feeder)
+  feeder: Feeder;
+
+  @Column('tinyint')
+  weekday: number; // 0~6 representing Monday-Sunday
+
+  @Column({ type: 'varchar', length: 8 })
+  startTime: string; // e.g. '09:00:00'
+
+  @Column({ type: 'varchar', length: 8 })
+  endTime: string; // e.g. '18:00:00'
+
+  @Column('tinyint', { default: 1 })
+  enabled: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.controller.ts
+++ b/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+  Req,
+  UseGuards,
+  NotFoundException,
+} from '@nestjs/common';
+import { FeederSchedulesService } from './feeder-schedules.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { BatchScheduleDto } from './dto/batch-schedule.dto';
+import { AdminJwtGuard } from '../admin/admin-jwt.guard';
+
+@Controller('feeder-schedules')
+export class FeederSchedulesController {
+  constructor(private readonly service: FeederSchedulesService) {}
+
+  @Post('batch')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('feeder')
+  async batch(@Req() req, @Body() dto: BatchScheduleDto) {
+    const feederId = await this.service.findFeederIdByUser(req.user.id);
+    if (!feederId) throw new NotFoundException('feeder not found');
+    return this.service.saveBatch(feederId, dto.items);
+  }
+
+  @Get('me')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('feeder')
+  async getMine(@Req() req) {
+    const feederId = await this.service.findFeederIdByUser(req.user.id);
+    if (!feederId) throw new NotFoundException('feeder not found');
+    return this.service.findByFeeder(feederId);
+  }
+
+  @Get(':feederId')
+  @UseGuards(AdminJwtGuard, RolesGuard)
+  @Roles('super', 'operator')
+  getByFeeder(@Param('feederId') feederId: string) {
+    return this.service.findByFeeder(Number(feederId));
+  }
+
+  @Put(':feederId')
+  @UseGuards(AdminJwtGuard, RolesGuard)
+  @Roles('super', 'operator')
+  updateByFeeder(
+    @Param('feederId') feederId: string,
+    @Body() dto: BatchScheduleDto,
+  ) {
+    return this.service.saveBatch(Number(feederId), dto.items);
+  }
+}

--- a/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.module.ts
+++ b/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FeederSchedulesService } from './feeder-schedules.service';
+import { FeederSchedulesController } from './feeder-schedules.controller';
+import { FeederSchedule } from './entities/feeder-schedule.entity';
+import { Feeder } from '../feeders/entities/feeder.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FeederSchedule, Feeder])],
+  controllers: [FeederSchedulesController],
+  providers: [FeederSchedulesService],
+})
+export class FeederSchedulesModule {}

--- a/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.service.ts
+++ b/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FeederSchedule } from './entities/feeder-schedule.entity';
+import { ScheduleItemDto } from './dto/schedule-item.dto';
+import { Feeder } from '../feeders/entities/feeder.entity';
+
+@Injectable()
+export class FeederSchedulesService {
+  constructor(
+    @InjectRepository(FeederSchedule)
+    private repository: Repository<FeederSchedule>,
+    @InjectRepository(Feeder)
+    private feeders: Repository<Feeder>,
+  ) {}
+
+  /**
+   * Overwrite schedules of given feeder with provided list.
+   */
+  async saveBatch(feederId: number, items: ScheduleItemDto[]) {
+    await this.repository.delete({ feeder: { id: feederId } });
+    const entities = items.map((i) =>
+      this.repository.create({
+        feeder: { id: feederId } as Feeder,
+        weekday: i.weekday,
+        startTime: i.startTime,
+        endTime: i.endTime,
+        enabled: i.enabled ?? 1,
+      }),
+    );
+    return this.repository.save(entities);
+  }
+
+  /** Find schedules belonging to a feeder. */
+  findByFeeder(feederId: number) {
+    return this.repository.find({
+      where: { feeder: { id: feederId } },
+      order: { weekday: 'ASC', startTime: 'ASC' },
+    });
+  }
+
+  /**
+   * Determine if feeder is available for requested time range.
+   */
+  async isFeederAvailable(
+    feederId: number,
+    weekday: number,
+    start: string,
+    end: string,
+  ) {
+    const list = await this.findByFeeder(feederId);
+    return list.some(
+      (s) =>
+        s.enabled &&
+        s.weekday === weekday &&
+        s.startTime <= start &&
+        s.endTime >= end,
+    );
+  }
+
+  /** Helper to get feederId via user id. */
+  async findFeederIdByUser(userId: number) {
+    const feeder = await this.feeders.findOne({ where: { user: { id: userId } } });
+    return feeder?.id ?? null;
+  }
+}

--- a/frontend/miniapp/pages.json
+++ b/frontend/miniapp/pages.json
@@ -14,7 +14,8 @@
     {"path": "pages/user/profile", "style": {"navigationBarTitleText": "个人中心"}},
     {"path": "pages/pay/result", "style": {"navigationBarTitleText": "支付结果"}},
     {"path": "pages/feeder/apply", "style": {"navigationBarTitleText": "喂养员申请"}},
-    {"path": "pages/feeder/status", "style": {"navigationBarTitleText": "审核状态"}}
+    {"path": "pages/feeder/status", "style": {"navigationBarTitleText": "审核状态"}},
+    {"path": "pages/feeder/schedule", "style": {"navigationBarTitleText": "排班设置"}}
   ],
   "globalStyle": {
     "navigationBarTitleText": "Pet Feeder",

--- a/frontend/miniapp/pages/feeder/schedule.vue
+++ b/frontend/miniapp/pages/feeder/schedule.vue
@@ -1,0 +1,94 @@
+<template>
+  <view class="container">
+    <view class="tabs">
+      <view
+        v-for="(d, i) in weekdays"
+        :key="i"
+        :class="['tab', { active: selectedDay === i }]"
+        @click="selectedDay = i"
+      >{{ d }}</view>
+    </view>
+    <view class="item" v-for="(r, idx) in dayRanges" :key="idx">
+      <picker mode="time" :value="r.startTime" @change="changeTime(idx, 'startTime', $event)">
+        <view class="time">{{ r.startTime || '开始时间' }}</view>
+      </picker>
+      <picker mode="time" :value="r.endTime" @change="changeTime(idx, 'endTime', $event)">
+        <view class="time">{{ r.endTime || '结束时间' }}</view>
+      </picker>
+      <button size="mini" @click="removeRange(idx)">删除</button>
+    </view>
+    <button size="mini" @click="addRange">添加时间段</button>
+    <button type="primary" @click="save" :loading="isLoading">保存</button>
+  </view>
+</template>
+
+<script>
+import { request } from '@/utils/request'
+export default {
+  data() {
+    return {
+      weekdays: ['周一','周二','周三','周四','周五','周六','周日'],
+      selectedDay: 0,
+      scheduleList: [],
+      isLoading: false
+    }
+  },
+  computed: {
+    dayRanges() {
+      const day = this.scheduleList.find(s => s.weekday === this.selectedDay)
+      return day ? day.ranges : []
+    }
+  },
+  onLoad() {
+    this.initList()
+  },
+  methods: {
+    initList() {
+      this.isLoading = true
+      request({ url: '/feeder-schedules/me' }).then(res => {
+        this.scheduleList = [0,1,2,3,4,5,6].map(i => ({
+          weekday: i,
+          ranges: res.filter(r => r.weekday === i).map(v => ({
+            startTime: v.startTime,
+            endTime: v.endTime
+          }))
+        }))
+      }).finally(() => { this.isLoading = false })
+    },
+    addRange() {
+      const day = this.scheduleList.find(s => s.weekday === this.selectedDay)
+      if (day) day.ranges.push({ startTime: '09:00:00', endTime: '18:00:00' })
+    },
+    removeRange(i) {
+      const day = this.scheduleList.find(s => s.weekday === this.selectedDay)
+      if (day) day.ranges.splice(i, 1)
+    },
+    changeTime(i, field, e) {
+      const day = this.scheduleList.find(s => s.weekday === this.selectedDay)
+      if (day) day.ranges[i][field] = e.detail.value + ':00'
+    },
+    save() {
+      const items = this.scheduleList.flatMap(d =>
+        d.ranges.map(r => ({
+          weekday: d.weekday,
+          startTime: r.startTime,
+          endTime: r.endTime
+        }))
+      )
+      this.isLoading = true
+      request({ url: '/feeder-schedules/batch', method: 'POST', data: { items } })
+        .then(() => uni.showToast({ title: '保存成功' }))
+        .finally(() => { this.isLoading = false })
+    }
+  }
+}
+</script>
+
+<style>
+.container { padding: 20rpx; }
+.tabs { display: flex; margin-bottom: 20rpx; }
+.tab { flex: 1; text-align: center; padding: 10rpx; border-bottom: 2rpx solid #eee; }
+.tab.active { border-color: #007aff; color: #007aff; }
+.item { display: flex; align-items: center; margin: 10rpx 0; }
+.time { width: 200rpx; }
+</style>


### PR DESCRIPTION
## Summary
- implement FeederSchedulesModule with entity, DTOs, service and controller
- register module in app.module
- add schedule management page for feeders
- register the new page in pages.json

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0c7c7a6883208c8eb28b5708687d