### PR TITLE
Refactor service flow into feeder orders

### DIFF
--- a/backend/pet-feeder-backend/src/feeder-orders/dto/create-feeder-order.dto.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/dto/create-feeder-order.dto.ts
@@ -2,6 +2,7 @@ export class CreateFeederOrderDto {
   userId: number;
   feederId: number;
   petId: number;
+  orderId: number;
   serviceTime: Date;
   address: string;
 }

--- a/backend/pet-feeder-backend/src/feeder-orders/dto/sign-in.dto.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/dto/sign-in.dto.ts
@@ -1,0 +1,4 @@
+export class SignInDto {
+  lat: number;
+  lng: number;
+}

--- a/backend/pet-feeder-backend/src/feeder-orders/entities/feeder-order.entity.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/entities/feeder-order.entity.ts
@@ -9,14 +9,8 @@ import {
 import { User } from '../../users/entities/user.entity';
 import { Feeder } from '../../feeders/entities/feeder.entity';
 import { Pet } from '../../pets/entities/pet.entity';
-
-export enum FeederOrderStatus {
-  PENDING = 'pending',
-  ACCEPTED = 'accepted',
-  REJECTED = 'rejected',
-  SERVING = 'serving',
-  COMPLETED = 'completed',
-}
+import { Order } from '../../orders/entities/order.entity';
+import { FeederOrderStatus } from '../status.enum';
 
 @Entity('feeder_orders')
 export class FeederOrder {
@@ -32,6 +26,9 @@ export class FeederOrder {
   @ManyToOne(() => Pet)
   pet: Pet;
 
+  @ManyToOne(() => Order)
+  baseOrder: Order;
+
   @Column('datetime')
   serviceTime: Date;
 
@@ -44,6 +41,24 @@ export class FeederOrder {
     default: FeederOrderStatus.PENDING,
   })
   status: FeederOrderStatus;
+
+  @Column('decimal', { precision: 9, scale: 6, nullable: true })
+  signInLat?: number;
+
+  @Column('decimal', { precision: 9, scale: 6, nullable: true })
+  signInLng?: number;
+
+  @Column({ type: 'datetime', nullable: true })
+  signInTime?: Date;
+
+  @Column({ type: 'datetime', nullable: true })
+  completeTime?: Date;
+
+  @Column({ type: 'simple-json', nullable: true })
+  completeImages?: string[];
+
+  @Column({ type: 'text', nullable: true })
+  description?: string;
 
   @Column({ type: 'simple-json', nullable: true })
   images?: string[];

--- a/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.controller.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.controller.ts
@@ -5,16 +5,27 @@ import {
   Param,
   Patch,
   Post,
+  Req,
   Query,
 } from '@nestjs/common';
 import { FeederOrdersService } from './feeder-orders.service';
 import { CreateFeederOrderDto } from './dto/create-feeder-order.dto';
 import { CompleteFeederOrderDto } from './dto/complete-feeder-order.dto';
 import { PaginateFeederOrderDto } from './dto/paginate-feeder-order.dto';
+import { SignInDto } from './dto/sign-in.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { UseGuards } from '@nestjs/common';
+import { FeedersService } from '../feeders/feeders.service';
 
 @Controller('feeder-orders')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class FeederOrdersController {
-  constructor(private readonly service: FeederOrdersService) {}
+  constructor(
+    private readonly service: FeederOrdersService,
+    private readonly feedersService: FeedersService,
+  ) {}
 
   /** 创建订单（测试用） */
   @Post()
@@ -33,9 +44,26 @@ export class FeederOrdersController {
     return this.service.paginateByFeeder(+feederId, page, limit);
   }
 
+  /** 当前喂养员订单列表 */
+  @Get('my')
+  @Roles('feeder')
+  async my(@Req() req, @Query() query: PaginateFeederOrderDto) {
+    const feeder = await this.feedersService.findByUserId(req.user.userId);
+    const page = Number(query.page) || 1;
+    const limit = Number(query.limit) || 10;
+    return this.service.paginateByFeeder(feeder.id, page, limit);
+  }
+
   /** 确认订单 */
   @Patch(':id/confirm')
   confirm(@Param('id') id: string) {
+    return this.service.confirm(+id);
+  }
+
+  /** 新接口：接受订单 */
+  @Post(':id/accept')
+  @Roles('feeder')
+  accept(@Param('id') id: string) {
     return this.service.confirm(+id);
   }
 
@@ -51,9 +79,41 @@ export class FeederOrdersController {
     return this.service.start(+id);
   }
 
+  /** 签到 */
+  @Patch(':id/sign-in')
+  signIn(@Param('id') id: string, @Body() dto: SignInDto) {
+    return this.service.signIn(+id, dto);
+  }
+
+  /** 出发 */
+  @Patch(':id/depart')
+  depart(@Param('id') id: string) {
+    return this.service.depart(+id);
+  }
+
+  /** 新接口：开始服务 */
+  @Post(':id/start-service')
+  @Roles('feeder')
+  startService(@Param('id') id: string) {
+    return this.service.start(+id);
+  }
+
   /** 完成服务并上传图片、备注 */
   @Patch(':id/complete')
   complete(@Param('id') id: string, @Body() dto: CompleteFeederOrderDto) {
     return this.service.complete(+id, dto);
+  }
+
+  /** 新接口：完成服务并上传图片、备注 */
+  @Post(':id/complete-service')
+  @Roles('feeder')
+  completeService(@Param('id') id: string, @Body() dto: CompleteFeederOrderDto) {
+    return this.service.complete(+id, dto);
+  }
+
+  /** 取消服务 */
+  @Patch(':id/cancel')
+  cancel(@Param('id') id: string) {
+    return this.service.cancel(+id);
   }
 }

--- a/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.module.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.module.ts
@@ -3,9 +3,17 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { FeederOrdersService } from './feeder-orders.service';
 import { FeederOrdersController } from './feeder-orders.controller';
 import { FeederOrder } from './entities/feeder-order.entity';
+import { Feeder } from '../feeders/entities/feeder.entity';
+import { Order } from '../orders/entities/order.entity';
+import { TrackingModule } from '../tracking/tracking.module';
+import { FeedersModule } from '../feeders/feeders.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([FeederOrder])],
+  imports: [
+    TypeOrmModule.forFeature([FeederOrder, Feeder, Order]),
+    TrackingModule,
+    FeedersModule,
+  ],
   controllers: [FeederOrdersController],
   providers: [FeederOrdersService],
 })

--- a/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.service.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/feeder-orders.service.ts
@@ -1,30 +1,61 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, HttpStatus } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { FeederOrder, FeederOrderStatus } from './entities/feeder-order.entity';
+import { Repository, QueryFailedError } from 'typeorm';
+import { FeederOrder } from './entities/feeder-order.entity';
+import { FeederOrderStatus } from './status.enum';
 import { CreateFeederOrderDto } from './dto/create-feeder-order.dto';
 import { CompleteFeederOrderDto } from './dto/complete-feeder-order.dto';
+import { SignInDto } from './dto/sign-in.dto';
 import { User } from '../users/entities/user.entity';
 import { Feeder } from '../feeders/entities/feeder.entity';
 import { Pet } from '../pets/entities/pet.entity';
+import { Order } from '../orders/entities/order.entity';
+import { TrackingGateway } from '../tracking/tracking.gateway';
+import { WxTemplateService } from '../tracking/wx-template.service';
+import { BusinessException } from '../common/exceptions/business.exception';
 
 @Injectable()
 export class FeederOrdersService {
   constructor(
     @InjectRepository(FeederOrder)
     private orders: Repository<FeederOrder>,
+    @InjectRepository(Feeder)
+    private feeders: Repository<Feeder>,
+    private gateway: TrackingGateway,
+    private wxService: WxTemplateService,
   ) {}
 
-  create(dto: CreateFeederOrderDto) {
+  async create(dto: CreateFeederOrderDto) {
+    const feeder = await this.feeders.findOne({ where: { id: dto.feederId } });
+    if (feeder?.isBlacklist) {
+      throw new BusinessException(3001, 'BLACKLIST', HttpStatus.FORBIDDEN);
+    }
+    const existing = await this.orders.findOne({
+      where: { baseOrder: { id: dto.orderId } },
+    });
+    if (existing) {
+      throw new BusinessException(3002, 'ORDER_TAKEN', HttpStatus.CONFLICT);
+    }
+
     const entity = this.orders.create({
       user: { id: dto.userId } as User,
       feeder: { id: dto.feederId } as Feeder,
       pet: { id: dto.petId } as Pet,
       serviceTime: dto.serviceTime,
       address: dto.address,
-      status: FeederOrderStatus.PENDING,
+      baseOrder: { id: dto.orderId } as Order,
+      status: FeederOrderStatus.ACCEPTED,
     });
-    return this.orders.save(entity);
+    try {
+      const saved = await this.orders.save(entity);
+      this.gateway.notifyStatus(saved.id, FeederOrderStatus.ACCEPTED);
+      return saved;
+    } catch (err) {
+      if (err instanceof QueryFailedError) {
+        throw new BusinessException(3002, 'ORDER_TAKEN', HttpStatus.CONFLICT);
+      }
+      throw err;
+    }
   }
 
   async paginateByFeeder(feederId: number, page: number, limit: number) {
@@ -44,29 +75,67 @@ export class FeederOrdersService {
     return order;
   }
 
-  async confirm(id: number) {
-    const order = await this.get(id);
-    order.status = FeederOrderStatus.ACCEPTED;
-    return this.orders.save(order);
+  private async updateStatus(
+    id: number,
+    status: FeederOrderStatus,
+    extra: Record<string, any> = {},
+  ) {
+    this.gateway.notifyStatus(id, status);
+    const res = await this.orders.update(id, { status, ...extra });
+    const templateMap: Record<FeederOrderStatus, string> = {
+      [FeederOrderStatus.ACCEPTED]: 'accept_tpl',
+      [FeederOrderStatus.DEPARTED]: 'depart_tpl',
+      [FeederOrderStatus.SIGNED_IN]: 'signin_tpl',
+      [FeederOrderStatus.SERVING]: 'serving_tpl',
+      [FeederOrderStatus.COMPLETED]: 'complete_tpl',
+      [FeederOrderStatus.CANCELED]: 'cancel_tpl',
+      [FeederOrderStatus.REJECTED]: 'reject_tpl',
+      [FeederOrderStatus.PENDING]: 'pending_tpl',
+    };
+    const tpl = templateMap[status];
+    if (tpl) {
+      const detail = await this.get(id);
+      const openid = detail?.user?.openid;
+      if (openid) {
+        this.wxService.send(openid, tpl, { status }, `/pages/orders/detail?id=${detail.baseOrder.id}`);
+      }
+    }
+    return res;
   }
 
-  async reject(id: number) {
-    const order = await this.get(id);
-    order.status = FeederOrderStatus.REJECTED;
-    return this.orders.save(order);
+  confirm(id: number) {
+    return this.updateStatus(id, FeederOrderStatus.ACCEPTED);
   }
 
-  async start(id: number) {
-    const order = await this.get(id);
-    order.status = FeederOrderStatus.SERVING;
-    return this.orders.save(order);
+  reject(id: number) {
+    return this.updateStatus(id, FeederOrderStatus.REJECTED);
   }
 
-  async complete(id: number, dto: CompleteFeederOrderDto) {
-    const order = await this.get(id);
-    order.status = FeederOrderStatus.COMPLETED;
-    order.images = dto.images;
-    order.remark = dto.remark;
-    return this.orders.save(order);
+  depart(id: number) {
+    return this.updateStatus(id, FeederOrderStatus.DEPARTED);
+  }
+
+  signIn(id: number, dto: SignInDto) {
+    return this.updateStatus(id, FeederOrderStatus.SIGNED_IN, {
+      signInLat: dto.lat,
+      signInLng: dto.lng,
+      signInTime: new Date(),
+    });
+  }
+
+  start(id: number) {
+    return this.updateStatus(id, FeederOrderStatus.SERVING);
+  }
+
+  complete(id: number, dto: CompleteFeederOrderDto) {
+    return this.updateStatus(id, FeederOrderStatus.COMPLETED, {
+      completeTime: new Date(),
+      description: dto.remark,
+      completeImages: dto.images,
+    });
+  }
+
+  cancel(id: number) {
+    return this.updateStatus(id, FeederOrderStatus.CANCELED);
   }
 }

--- a/backend/pet-feeder-backend/src/feeder-orders/status.enum.ts
+++ b/backend/pet-feeder-backend/src/feeder-orders/status.enum.ts
@@ -1,0 +1,10 @@
+export enum FeederOrderStatus {
+  PENDING = 0,
+  ACCEPTED = 1,
+  DEPARTED = 2,
+  SIGNED_IN = 3,
+  SERVING = 4,
+  COMPLETED = 5,
+  CANCELED = 6,
+  REJECTED = 7,
+}

--- a/backend/pet-feeder-backend/src/feeders/feeders.module.ts
+++ b/backend/pet-feeder-backend/src/feeders/feeders.module.ts
@@ -9,5 +9,6 @@ import { Feeder } from './entities/feeder.entity';
   imports: [TypeOrmModule.forFeature([Feeder])],
   controllers: [FeedersController, FeederSelfController],
   providers: [FeedersService],
+  exports: [FeedersService],
 })
 export class FeedersModule {}


### PR DESCRIPTION
## Summary
- centralize service logic under `feeder-orders`
- expose new order status enum
- expand `FeederOrder` entity with service flow fields
- add authenticated feeder order APIs
- export `FeedersService` for reuse

## Testing
- `npm install` *(fails: 403 Forbidden for registry.npmmirror.com)*

------
https://chatgpt.com/codex/tasks/task_e_687b114c0bb88320a5d30926bdf326ff