### PR TITLE
Implement feeder schedule management APIs

### DIFF
--- a/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.controller.ts
+++ b/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.controller.ts
@@ -8,6 +8,7 @@ import {
   Req,
   UseGuards,
   NotFoundException,
+  Query,
 } from '@nestjs/common';
 import { FeederSchedulesService } from './feeder-schedules.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -36,6 +37,26 @@ export class FeederSchedulesController {
     const feederId = await this.service.findFeederIdByUser(req.user.id);
     if (!feederId) throw new NotFoundException('feeder not found');
     return this.service.findByFeeder(feederId);
+  }
+
+  @Get('available')
+  async available(@Query('start') start: string, @Query('end') end: string) {
+    const s = new Date(start);
+    const e = end ? new Date(end) : new Date(start);
+    return this.service.findAvailableFeeders(s, e);
+  }
+
+  @Get()
+  @UseGuards(AdminJwtGuard, RolesGuard)
+  @Roles('super', 'operator')
+  async list(
+    @Query('page') page = '1',
+    @Query('limit') limit = '10',
+    @Query('name') name?: string,
+  ) {
+    const p = parseInt(page, 10) || 1;
+    const l = parseInt(limit, 10) || 10;
+    return this.service.paginateAll(p, l, name);
   }
 
   @Get(':feederId')

--- a/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.module.ts
+++ b/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.module.ts
@@ -4,10 +4,12 @@ import { FeederSchedulesService } from './feeder-schedules.service';
 import { FeederSchedulesController } from './feeder-schedules.controller';
 import { FeederSchedule } from './entities/feeder-schedule.entity';
 import { Feeder } from '../feeders/entities/feeder.entity';
+import { FeederOrder } from '../feeder-orders/entities/feeder-order.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([FeederSchedule, Feeder])],
+  imports: [TypeOrmModule.forFeature([FeederSchedule, Feeder, FeederOrder])],
   controllers: [FeederSchedulesController],
   providers: [FeederSchedulesService],
+  exports: [FeederSchedulesService],
 })
 export class FeederSchedulesModule {}

--- a/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.service.ts
+++ b/backend/pet-feeder-backend/src/feeder-schedules/feeder-schedules.service.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, MoreThan, Not, In, Between } from 'typeorm';
 import { FeederSchedule } from './entities/feeder-schedule.entity';
 import { ScheduleItemDto } from './dto/schedule-item.dto';
 import { Feeder } from '../feeders/entities/feeder.entity';
+import { FeederOrder } from '../feeder-orders/entities/feeder-order.entity';
+import { FeederOrderStatus } from '../feeder-orders/status.enum';
+import { BusinessException } from '../common/exceptions/business.exception';
 
 @Injectable()
 export class FeederSchedulesService {
@@ -12,12 +15,15 @@ export class FeederSchedulesService {
     private repository: Repository<FeederSchedule>,
     @InjectRepository(Feeder)
     private feeders: Repository<Feeder>,
+    @InjectRepository(FeederOrder)
+    private feederOrders: Repository<FeederOrder>,
   ) {}
 
   /**
    * Overwrite schedules of given feeder with provided list.
    */
   async saveBatch(feederId: number, items: ScheduleItemDto[]) {
+    await this.assertNoConflict(feederId, items);
     await this.repository.delete({ feeder: { id: feederId } });
     const entities = items.map((i) =>
       this.repository.create({
@@ -29,6 +35,21 @@ export class FeederSchedulesService {
       }),
     );
     return this.repository.save(entities);
+  }
+
+  /** Save schedules by user id */
+  async saveForUser(userId: number, items: ScheduleItemDto[]) {
+    const feederId = await this.findFeederIdByUser(userId);
+    if (!feederId) throw new BusinessException(4004, 'FEEDER_NOT_FOUND');
+    await this.assertNoConflict(feederId, items);
+    return this.saveBatch(feederId, items);
+  }
+
+  /** List schedules by user id */
+  async listForUser(userId: number) {
+    const feederId = await this.findFeederIdByUser(userId);
+    if (!feederId) throw new BusinessException(4004, 'FEEDER_NOT_FOUND');
+    return this.findByFeeder(feederId);
   }
 
   /** Find schedules belonging to a feeder. */
@@ -62,5 +83,70 @@ export class FeederSchedulesService {
   async findFeederIdByUser(userId: number) {
     const feeder = await this.feeders.findOne({ where: { user: { id: userId } } });
     return feeder?.id ?? null;
+  }
+
+  /** Validate upcoming orders still fit new schedules */
+  private async assertNoConflict(feederId: number, items: ScheduleItemDto[]) {
+    const upcoming = await this.feederOrders.find({
+      where: {
+        feeder: { id: feederId },
+        serviceTime: MoreThan(new Date()),
+        status: Not(In([FeederOrderStatus.CANCELED, FeederOrderStatus.REJECTED])),
+      },
+    });
+    for (const order of upcoming) {
+      const weekday = (order.serviceTime.getDay() + 6) % 7;
+      const time = order.serviceTime.toTimeString().slice(0, 8);
+      const ok = items.some(
+        (i) =>
+          i.weekday === weekday && i.startTime <= time && i.endTime >= time,
+      );
+      if (!ok)
+        throw new BusinessException(4005, 'SCHEDULE_CONFLICT_WITH_ORDER');
+    }
+  }
+
+  /** Find available feeders for time range */
+  async findAvailableFeeders(start: Date, end: Date) {
+    const weekday = (start.getDay() + 6) % 7;
+    const startStr = start.toTimeString().slice(0, 8);
+    const endStr = end.toTimeString().slice(0, 8);
+    const qb = this.repository
+      .createQueryBuilder('s')
+      .innerJoinAndSelect('s.feeder', 'f')
+      .where('s.enabled = 1')
+      .andWhere('f.status = 1')
+      .andWhere('f.isBlacklist = 0')
+      .andWhere('s.weekday = :weekday', { weekday })
+      .andWhere('s.startTime <= :start', { start: startStr })
+      .andWhere('s.endTime >= :end', { end: endStr });
+    const schedules = await qb.getMany();
+    if (schedules.length === 0) return [];
+    const busy = await this.feederOrders.find({
+      where: {
+        feeder: In(schedules.map((s) => s.feeder.id)),
+        serviceTime: Between(start, end),
+        status: Not(In([FeederOrderStatus.CANCELED, FeederOrderStatus.REJECTED])),
+      },
+      relations: ['feeder'],
+    });
+    const busyIds = new Set(busy.map((o) => o.feeder.id));
+    return schedules
+      .map((s) => s.feeder)
+      .filter((f) => !busyIds.has(f.id));
+  }
+
+  /** Paginate feeders with schedules for admin */
+  async paginateAll(page: number, limit: number, name?: string) {
+    const qb = this.feeders.createQueryBuilder('f');
+    if (name) qb.where('f.name like :n', { n: `%${name}%` });
+    qb.skip((page - 1) * limit).take(limit);
+    const [feeders, total] = await qb.getManyAndCount();
+    const items = [] as any[];
+    for (const f of feeders) {
+      const schedules = await this.findByFeeder(f.id);
+      items.push({ feeder: f, schedules });
+    }
+    return { items, total, page, limit };
   }
 }

--- a/backend/pet-feeder-backend/src/feeders/feeder-self.controller.ts
+++ b/backend/pet-feeder-backend/src/feeders/feeder-self.controller.ts
@@ -1,14 +1,19 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards, Query } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Roles } from '../common/decorators/roles.decorator';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { FeedersService } from './feeders.service';
 import { ApplyFeederDto } from './dto/apply-feeder.dto';
+import { FeederSchedulesService } from '../feeder-schedules/feeder-schedules.service';
+import { BatchScheduleDto } from '../feeder-schedules/dto/batch-schedule.dto';
 
 @Controller('feeder')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class FeederSelfController {
-  constructor(private readonly service: FeedersService) {}
+  constructor(
+    private readonly service: FeedersService,
+    private readonly schedules: FeederSchedulesService,
+  ) {}
 
   @Post('apply')
   @Roles('user')
@@ -20,5 +25,20 @@ export class FeederSelfController {
   @Roles('user', 'feeder', 'admin')
   profile(@Req() req) {
     return this.service.findByUserId(req.user.id);
+  }
+
+  /** 提交排班计划 */
+  @Post('schedule')
+  @Roles('feeder')
+  submitSchedule(@Req() req, @Body() dto: BatchScheduleDto) {
+    return this.schedules.saveForUser(req.user.id, dto.items);
+  }
+
+  /** 获取排班信息，可指定喂养员 */
+  @Get('schedule')
+  @Roles('feeder', 'operator', 'super')
+  getSchedule(@Req() req, @Query('feederId') feederId?: string) {
+    const id = feederId ? parseInt(feederId, 10) : req.user.id;
+    return this.schedules.listForUser(id);
   }
 }

--- a/backend/pet-feeder-backend/src/feeders/feeders.module.ts
+++ b/backend/pet-feeder-backend/src/feeders/feeders.module.ts
@@ -4,9 +4,10 @@ import { FeedersService } from './feeders.service';
 import { FeedersController } from './feeders.controller';
 import { FeederSelfController } from './feeder-self.controller';
 import { Feeder } from './entities/feeder.entity';
+import { FeederSchedulesModule } from '../feeder-schedules/feeder-schedules.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Feeder])],
+  imports: [TypeOrmModule.forFeature([Feeder]), FeederSchedulesModule],
   controllers: [FeedersController, FeederSelfController],
   providers: [FeedersService],
   exports: [FeedersService],


### PR DESCRIPTION
## Summary
- expose feeder schedule service through module export
- allow feeders to manage schedules via `/feeder/schedule`
- add admin listing and available-feeders API
- validate schedule conflicts with upcoming orders

## Testing
- `npx tsc -p backend/pet-feeder-backend/tsconfig.json` *(fails: Cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_e_687bc3932a9483208707323be1bf77ae