### PR TITLE
Migrate admin Vue pages to Naive UI

### DIFF
--- a/frontend/admin-vue/README.md
+++ b/frontend/admin-vue/README.md
@@ -1,9 +1,15 @@
 # Vue Admin
 
-This directory contains a minimal Vue3 + Element Plus admin console example.
+This directory contains a minimal Vue3 admin console using Naive UI components.
 
 Pages:
 - `FeederAudit.vue` – list feeders pending approval with approve/reject actions.
 - `OrderList.vue` – view orders and update status.
+- `UserManagement.vue` – manage platform users (placeholder).
+- `PetInfoManagement.vue` – manage pet profiles (placeholder).
+- `ServiceManagement.vue` – manage services offered (placeholder).
+- `ServiceBooking.vue` – manage service bookings (placeholder).
+- `FeederSchedule.vue` – manage feeders schedule & performance (placeholder).
+- `FinanceSettlement.vue` – handle finance settlement tasks (placeholder).
 
-This is only a starter implementation; expand it to cover full management features.
+These pages provide only basic layout. Business logic should be implemented as needed.

--- a/frontend/admin-vue/src/FeederAudit.vue
+++ b/frontend/admin-vue/src/FeederAudit.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted } from 'vue';
 import { baseUrl } from '../config';
-import { ElMessageBox } from 'element-plus';
+// Naive UI does not provide a built-in prompt dialog, use browser prompt
 const feeders = ref([]);
 const fetchFeeders = async () => {
   const res = await fetch(baseUrl + '/admin/feeders');
@@ -11,12 +11,8 @@ const fetchFeeders = async () => {
 const audit = async (id, approve) => {
   let reason = '';
   if (!approve) {
-    const res = await ElMessageBox.prompt('请输入拒绝原因', '驳回', {
-      confirmButtonText: '确定',
-      cancelButtonText: '取消',
-    }).catch(() => null);
-    if (!res) return;
-    reason = res.value;
+    reason = window.prompt('请输入拒绝原因') || '';
+    if (!reason) return;
   }
   await fetch(baseUrl + `/admin/feeders/${id}/audit`, {
     method: 'PATCH',
@@ -28,14 +24,23 @@ const audit = async (id, approve) => {
 onMounted(fetchFeeders);
 </script>
 <template>
-  <el-table :data="feeders" style="width: 100%">
-    <el-table-column prop="name" label="Name" />
-    <el-table-column prop="phone" label="Phone" />
-    <el-table-column>
-      <template #default="{ row }">
-        <el-button type="success" @click="audit(row.id, true)">Approve</el-button>
-        <el-button type="danger" @click="audit(row.id, false)">Reject</el-button>
-      </template>
-    </el-table-column>
-  </el-table>
+  <n-table :bordered="false" :single-line="false">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Phone</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="row in feeders" :key="row.id">
+        <td>{{ row.name }}</td>
+        <td>{{ row.phone }}</td>
+        <td>
+          <n-button size="small" type="success" @click="audit(row.id, true)">Approve</n-button>
+          <n-button size="small" type="error" @click="audit(row.id, false)">Reject</n-button>
+        </td>
+      </tr>
+    </tbody>
+  </n-table>
 </template>

--- a/frontend/admin-vue/src/FeederSchedule.vue
+++ b/frontend/admin-vue/src/FeederSchedule.vue
@@ -1,0 +1,8 @@
+<script setup>
+// Feeder scheduling and performance logic to be implemented
+</script>
+<template>
+  <n-card title="喂养员排班与绩效">
+    <n-data-table :columns="[]" :data="[]" />
+  </n-card>
+</template>

--- a/frontend/admin-vue/src/FinanceSettlement.vue
+++ b/frontend/admin-vue/src/FinanceSettlement.vue
@@ -1,0 +1,8 @@
+<script setup>
+// Finance settlement module logic to be implemented
+</script>
+<template>
+  <n-card title="财务结算模块">
+    <n-data-table :columns="[]" :data="[]" />
+  </n-card>
+</template>

--- a/frontend/admin-vue/src/OrderList.vue
+++ b/frontend/admin-vue/src/OrderList.vue
@@ -12,8 +12,18 @@ const fetchOrders = async () => {
 onMounted(fetchOrders);
 </script>
 <template>
-  <el-table :data="orders" style="width: 100%">
-    <el-table-column prop="id" label="ID" />
-    <el-table-column prop="status" label="Status" />
-  </el-table>
+  <n-table :bordered="false" :single-line="false">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="order in orders" :key="order.id">
+        <td>{{ order.id }}</td>
+        <td>{{ order.status }}</td>
+      </tr>
+    </tbody>
+  </n-table>
 </template>

--- a/frontend/admin-vue/src/PetInfoManagement.vue
+++ b/frontend/admin-vue/src/PetInfoManagement.vue
@@ -1,0 +1,8 @@
+<script setup>
+// Pet info management logic to be implemented
+</script>
+<template>
+  <n-card title="宠物信息管理">
+    <n-data-table :columns="[]" :data="[]" />
+  </n-card>
+</template>

--- a/frontend/admin-vue/src/ServiceBooking.vue
+++ b/frontend/admin-vue/src/ServiceBooking.vue
@@ -1,0 +1,8 @@
+<script setup>
+// Service booking logic to be implemented
+</script>
+<template>
+  <n-card title="服务预约管理">
+    <n-data-table :columns="[]" :data="[]" />
+  </n-card>
+</template>

--- a/frontend/admin-vue/src/ServiceManagement.vue
+++ b/frontend/admin-vue/src/ServiceManagement.vue
@@ -1,0 +1,8 @@
+<script setup>
+// Service management logic to be implemented
+</script>
+<template>
+  <n-card title="服务管理">
+    <n-data-table :columns="[]" :data="[]" />
+  </n-card>
+</template>

--- a/frontend/admin-vue/src/UserManagement.vue
+++ b/frontend/admin-vue/src/UserManagement.vue
@@ -1,0 +1,8 @@
+<script setup>
+// User management logic to be implemented
+</script>
+<template>
+  <n-card title="用户管理">
+    <n-data-table :columns="[]" :data="[]" />
+  </n-card>
+</template>

--- a/frontend/admin-vue/src/main.js
+++ b/frontend/admin-vue/src/main.js
@@ -1,6 +1,4 @@
 import { createApp } from 'vue';
-import ElementPlus from 'element-plus';
-import 'element-plus/dist/index.css';
+import naive from 'naive-ui';
 import FeederAudit from './FeederAudit.vue';
-
-createApp(FeederAudit).use(ElementPlus).mount('#app');
+createApp(FeederAudit).use(naive).mount('#app');


### PR DESCRIPTION
## Summary
- switch admin-vue project from Element Plus to Naive UI
- update FeederAudit and OrderList to use Naive UI components
- add skeleton pages for user, pet, service, booking, scheduling and finance modules
- update example README

## Testing
- `npm test` *(fails: Wechat web devTools not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6d69f85c8320b11a6b70f5fcc61c