### PR TITLE
Add RBAC entities and migration

### DIFF
--- a/backend/pet-feeder-backend/data-source.ts
+++ b/backend/pet-feeder-backend/data-source.ts
@@ -1,0 +1,13 @@
+import 'dotenv/config';
+import { DataSource } from 'typeorm';
+
+export default new DataSource({
+  type: 'mysql',
+  host: process.env.DB_HOST ?? 'localhost',
+  port: parseInt(process.env.DB_PORT ?? '3306', 10),
+  username: process.env.DB_USER ?? 'root',
+  password: process.env.DB_PASS ?? 'root',
+  database: process.env.DB_NAME ?? 'pet_feeder',
+  entities: ['src/**/*.entity.ts'],
+  migrations: ['src/migrations/*.ts'],
+});

--- a/backend/pet-feeder-backend/src/admin/entities/admin-user.entity.ts
+++ b/backend/pet-feeder-backend/src/admin/entities/admin-user.entity.ts
@@ -1,4 +1,12 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
+import { Role } from '../../roles/entities/role.entity';
 import { AdminRole } from '../admin-role.enum';
 
 @Entity('admin_user')
@@ -20,4 +28,13 @@ export class AdminUser {
 
   @CreateDateColumn()
   createTime: Date;
+
+  /** 关联角色列表 */
+  @ManyToMany(() => Role)
+  @JoinTable({
+    name: 'admin_user_roles',
+    joinColumn: { name: 'admin_user_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'role_id', referencedColumnName: 'id' },
+  })
+  roles: Role[];
 }

--- a/backend/pet-feeder-backend/src/migrations/1700000000000-CreateRbacSchema.ts
+++ b/backend/pet-feeder-backend/src/migrations/1700000000000-CreateRbacSchema.ts
@@ -1,0 +1,87 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateRbacSchema1700000000000 implements MigrationInterface {
+  name = 'CreateRbacSchema1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE roles (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(50) NOT NULL UNIQUE,
+        description VARCHAR(255) NULL
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TABLE permissions (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(100) NOT NULL UNIQUE,
+        description VARCHAR(255) NULL
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TABLE role_permissions (
+        role_id INT NOT NULL,
+        permission_id INT NOT NULL,
+        PRIMARY KEY (role_id, permission_id),
+        FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
+        FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TABLE user_roles (
+        user_id INT NOT NULL,
+        role_id INT NOT NULL,
+        PRIMARY KEY (user_id, role_id),
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+        FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TABLE admin_user_roles (
+        admin_user_id INT NOT NULL,
+        role_id INT NOT NULL,
+        PRIMARY KEY (admin_user_id, role_id),
+        FOREIGN KEY (admin_user_id) REFERENCES admin_user(id) ON DELETE CASCADE,
+        FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(`
+      INSERT INTO roles (name, description) VALUES
+        ('super', 'Super Administrator'),
+        ('operator', 'Operator'),
+        ('user', 'Regular user'),
+        ('feeder', 'Feeder')
+    `);
+    await queryRunner.query(`
+      INSERT INTO permissions (name, description) VALUES
+        ('admin:access', 'Access admin APIs'),
+        ('order:manage', 'Manage orders'),
+        ('feeder:approve', 'Approve feeders')
+    `);
+    await queryRunner.query(`
+      INSERT INTO role_permissions (role_id, permission_id)
+      SELECT r.id, p.id FROM roles r CROSS JOIN permissions p WHERE r.name = 'super'
+    `);
+    await queryRunner.query(`
+      INSERT INTO role_permissions (role_id, permission_id)
+      SELECT (SELECT id FROM roles WHERE name = 'operator'), p.id
+      FROM permissions p WHERE p.name IN ('order:manage','feeder:approve')
+    `);
+    await queryRunner.query(`
+      INSERT INTO user_roles (user_id, role_id)
+      SELECT id, (SELECT id FROM roles WHERE name = role) FROM users
+    `);
+    await queryRunner.query(`
+      INSERT INTO admin_user_roles (admin_user_id, role_id)
+      SELECT id, (SELECT id FROM roles WHERE name = role) FROM admin_user
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE admin_user_roles');
+    await queryRunner.query('DROP TABLE user_roles');
+    await queryRunner.query('DROP TABLE role_permissions');
+    await queryRunner.query('DROP TABLE permissions');
+    await queryRunner.query('DROP TABLE roles');
+  }
+}

--- a/backend/pet-feeder-backend/src/roles/entities/permission.entity.ts
+++ b/backend/pet-feeder-backend/src/roles/entities/permission.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Role } from './role.entity';
+
+@Entity('permissions')
+export class Permission {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 100, unique: true })
+  name: string;
+
+  @Column({ length: 255, nullable: true })
+  description?: string;
+
+  @ManyToMany(() => Role, (role) => role.permissions)
+  roles: Role[];
+}

--- a/backend/pet-feeder-backend/src/roles/entities/role.entity.ts
+++ b/backend/pet-feeder-backend/src/roles/entities/role.entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, ManyToMany, PrimaryGeneratedColumn, JoinTable } from 'typeorm';
+import { Permission } from './permission.entity';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('roles')
+export class Role {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 50, unique: true })
+  name: string;
+
+  @Column({ length: 255, nullable: true })
+  description?: string;
+
+  @ManyToMany(() => Permission, (permission) => permission.roles)
+  @JoinTable({
+    name: 'role_permissions',
+    joinColumn: { name: 'role_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'permission_id', referencedColumnName: 'id' },
+  })
+  permissions: Permission[];
+
+  @ManyToMany(() => User, (user) => user.roles)
+  users: User[];
+}

--- a/backend/pet-feeder-backend/src/users/entities/user.entity.ts
+++ b/backend/pet-feeder-backend/src/users/entities/user.entity.ts
@@ -1,4 +1,12 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  ManyToMany,
+  OneToMany,
+  JoinTable,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Role } from '../../roles/entities/role.entity';
 import { Pet } from '../../pets/entities/pet.entity';
 import { Order } from '../../orders/entities/order.entity';
 
@@ -40,4 +48,13 @@ export class User {
   /** 用户创建的订单 */
   @OneToMany(() => Order, (order) => order.user)
   orders: Order[];
+
+  /** 关联角色列表 */
+  @ManyToMany(() => Role, (role) => role.users)
+  @JoinTable({
+    name: 'user_roles',
+    joinColumn: { name: 'user_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'role_id', referencedColumnName: 'id' },
+  })
+  roles: Role[];
 }


### PR DESCRIPTION
## Summary
- create `Role` and `Permission` entities
- link `User` and `AdminUser` to roles via many-to-many relations
- add initial migration with seed data for roles and permissions
- provide TypeORM `DataSource` for migrations
- rename initial RBAC migration file to `CreateRbacSchema`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f622914e88320918399b345fa1bed