### PR TITLE
Implement admin auth info endpoint

### DIFF
--- a/backend/pet-feeder-backend/src/domains/admin/admin-auth.controller.ts
+++ b/backend/pet-feeder-backend/src/domains/admin/admin-auth.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { AdminUserService } from './admin-user.service';
+import { AdminJwtGuard } from './admin-jwt.guard';
+import { AdminAuthInfoDto } from './dto/admin-auth-info.dto';
+
+@Controller('admin/auth')
+export class AdminAuthController {
+  constructor(private readonly adminUserService: AdminUserService) {}
+
+  @UseGuards(AdminJwtGuard)
+  @Get('info')
+  async getAdminInfo(@Req() req): Promise<AdminAuthInfoDto> {
+    const userId = req.user.userId;
+    const adminUser = await this.adminUserService.findById(userId);
+    const roles = adminUser?.roles?.map((r) => r.code) || [];
+    const permissions: string[] = [];
+    const menus: any[] = [];
+    return {
+      id: adminUser.id,
+      username: adminUser.username,
+      nickname: adminUser.nickname,
+      roles,
+      permissions,
+      menus,
+    } as AdminAuthInfoDto;
+  }
+}

--- a/backend/pet-feeder-backend/src/domains/admin/admin.module.ts
+++ b/backend/pet-feeder-backend/src/domains/admin/admin.module.ts
@@ -8,6 +8,7 @@ import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { AdminUserController } from './admin-user.controller';
 import { AdminRoleController } from './admin-role.controller';
+import { AdminAuthController } from './admin-auth.controller';
 import { AdminUserService } from './admin-user.service';
 import { AdminRoleService } from './admin-role.service';
 import { AdminJwtGuard } from './admin-jwt.guard';
@@ -40,6 +41,7 @@ import { Feedback } from '../feedback/entities/feedback.entity';
     AdminController,
     AdminUserController,
     AdminRoleController,
+    AdminAuthController,
   ],
   providers: [
     AdminService,

--- a/backend/pet-feeder-backend/src/domains/admin/dto/admin-auth-info.dto.ts
+++ b/backend/pet-feeder-backend/src/domains/admin/dto/admin-auth-info.dto.ts
@@ -1,0 +1,19 @@
+import { AdminUser } from '../entities/admin-user.entity';
+
+export class AdminAuthInfoDto {
+  id: number;
+  username: string;
+  nickname?: string | null;
+  roles: string[];
+  permissions: string[];
+  menus: any[];
+
+  constructor(user: AdminUser, permissions: string[] = [], menus: any[] = []) {
+    this.id = user.id;
+    this.username = user.username;
+    this.nickname = user.nickname ?? null;
+    this.roles = user.roles?.map((r) => r.code) || [];
+    this.permissions = permissions;
+    this.menus = menus;
+  }
+}

--- a/backend/pet-feeder-backend/test/admin-auth-info.e2e-spec.ts
+++ b/backend/pet-feeder-backend/test/admin-auth-info.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import * as request from 'supertest';
+import { JwtService } from '@nestjs/jwt';
+import { AdminModule } from '../src/admin/admin.module';
+import { AdminUser } from '../src/admin/entities/admin-user.entity';
+import { AdminRole } from '../src/admin/entities/admin-role.entity';
+import { LoggingInterceptor } from '../src/common/interceptors/logging.interceptor';
+import { ResponseInterceptor } from '../src/common/interceptors/response.interceptor';
+
+async function createApp() {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [
+      TypeOrmModule.forRoot({
+        type: 'sqlite',
+        database: ':memory:',
+        dropSchema: true,
+        entities: [AdminUser, AdminRole],
+        synchronize: true,
+      }),
+      AdminModule,
+    ],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  app.useGlobalInterceptors(new LoggingInterceptor(), new ResponseInterceptor());
+  await app.init();
+  return app;
+}
+
+describe('admin auth info', () => {
+  let app: INestApplication;
+  let server: any;
+  let jwt: JwtService;
+
+  beforeAll(async () => {
+    app = await createApp();
+    server = app.getHttpServer();
+    jwt = app.get(JwtService);
+
+    const roleRepo = app.get(getRepositoryToken(AdminRole));
+    const userRepo = app.get(getRepositoryToken(AdminUser));
+    const role = await roleRepo.save({ code: 'super', name: 'Super' } as AdminRole);
+    await userRepo.save({ username: 'admin', password: 'pwd', roles: [role] } as any);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns current admin info', async () => {
+    const token = await jwt.signAsync({ sub: 1, role: 'super' });
+    const res = await request(server)
+      .get('/admin/auth/info')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body.data.username).toBe('admin');
+    expect(res.body.data.roles).toContain('super');
+  });
+});

--- a/backend/pet-feeder-backend/test/test-sequencer.js
+++ b/backend/pet-feeder-backend/test/test-sequencer.js
@@ -9,6 +9,7 @@ class CustomSequencer extends Sequencer {
       'feeder-workflow.e2e-spec.ts',
       'admin-workflow.e2e-spec.ts',
       'admin-user-role.e2e-spec.ts',
+      'admin-auth-info.e2e-spec.ts',
     ];
     const rank = (test) => {
       const file = path.basename(test.path);


### PR DESCRIPTION
## Summary
- support new `GET /admin/auth/info` endpoint
- expose info controller via AdminModule
- DTO for returning admin details
- test case for the auth info route
- include test in custom sequencer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688093672c08832098b8576d9f57cd06