### PR TITLE
Implement WeChat login flow and user profile endpoints

### DIFF
--- a/backend/pet-feeder-backend/src/common/utils/update-status.util.ts
+++ b/backend/pet-feeder-backend/src/common/utils/update-status.util.ts
@@ -24,11 +24,11 @@ export function createStatusUpdater<T extends ObjectLiteral>(
     const tpl = templateMap[status];
     if (tpl) {
       const detail = await findDetail(id);
-      const openid =
-        detail?.user?.openid ?? detail?.baseOrder?.user?.openid;
+      const openId =
+        detail?.user?.openId ?? detail?.baseOrder?.user?.openId;
       const orderId = detail?.baseOrder?.id ?? detail?.id;
-      if (openid && orderId) {
-        wxService.send(openid, tpl, { status }, `/pages/orders/detail?id=${orderId}`);
+      if (openId && orderId) {
+        wxService.send(openId, tpl, { status }, `/pages/orders/detail?id=${orderId}`);
       }
     }
     return res;

--- a/backend/pet-feeder-backend/src/domains/auth/auth.service.ts
+++ b/backend/pet-feeder-backend/src/domains/auth/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import { LoginDto } from './dto/login.dto';
+import { User } from '../users/entities/user.entity';
 
 @Injectable()
 export class AuthService {
@@ -11,10 +12,10 @@ export class AuthService {
   ) {}
 
   async validateOrCreateUser(loginDto: LoginDto) {
-    let user = await this.usersService.findByOpenid?.(loginDto.openid);
+    let user = await this.usersService.findByOpenId?.(loginDto.openId);
     if (!user) {
       user = await this.usersService.create({
-        openid: loginDto.openid,
+        openId: loginDto.openId,
         nickname: loginDto.nickname,
         avatar: loginDto.avatar,
       });
@@ -38,6 +39,46 @@ export class AuthService {
     return {
       access_token: await this.jwtService.signAsync(payload),
     };
+  }
+
+  async loginWithWechat(params: {
+    openid: string;
+    unionid?: string;
+    nickname?: string;
+    avatar?: string;
+  }) {
+    const { openid, unionid, nickname, avatar } = params;
+    let user = await this.usersService.findByOpenId(openid);
+    if (!user && unionid) {
+      user = await this.usersService.findByUnionId(unionid);
+    }
+    if (!user) {
+      user = await this.usersService.create({
+        openId: openid,
+        unionId: unionid,
+        nickname: nickname || '',
+        avatar: avatar || '',
+      });
+    } else {
+      const updated: Partial<User> = {};
+      if (unionid && !user.unionId) {
+        updated.unionId = unionid;
+      }
+      if (nickname && user.nickname !== nickname) {
+        updated.nickname = nickname;
+      }
+      if (avatar && user.avatar !== avatar) {
+        updated.avatar = avatar;
+      }
+      if (Object.keys(updated).length > 0) {
+        await this.usersService.update(user.id, updated as any);
+        Object.assign(user, updated);
+      }
+    }
+
+    const payload = { sub: user.id, role: user.role };
+    const token = await this.jwtService.signAsync(payload);
+    return { token, userInfo: user };
   }
 
   async profile(userId: number) {

--- a/backend/pet-feeder-backend/src/domains/auth/dto/login.dto.ts
+++ b/backend/pet-feeder-backend/src/domains/auth/dto/login.dto.ts
@@ -2,7 +2,7 @@ import { IsString } from 'class-validator';
 
 export class LoginDto {
   @IsString()
-  openid: string;
+  openId: string;
 
   @IsString()
   nickname: string;

--- a/backend/pet-feeder-backend/src/domains/auth/dto/wx-login.dto.ts
+++ b/backend/pet-feeder-backend/src/domains/auth/dto/wx-login.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+
+export class WxLoginDto {
+  @IsString()
+  @IsNotEmpty()
+  code: string;
+
+  @IsOptional()
+  @IsString()
+  nickname?: string;
+
+  @IsOptional()
+  @IsString()
+  avatar?: string;
+}

--- a/backend/pet-feeder-backend/src/domains/auth/jwt.strategy.ts
+++ b/backend/pet-feeder-backend/src/domains/auth/jwt.strategy.ts
@@ -16,8 +16,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload: any) {
     return {
       userId: payload.sub,
-      roles: payload.roles || [],
-      permissions: payload.permissions || [],
+      role: payload.role,
     };
   }
 }

--- a/backend/pet-feeder-backend/src/domains/auth/wechat.service.spec.ts
+++ b/backend/pet-feeder-backend/src/domains/auth/wechat.service.spec.ts
@@ -1,26 +1,16 @@
 import axios from 'axios';
 import { WechatService } from './wechat.service';
 import { UnauthorizedException } from '@nestjs/common';
-import * as fs from 'fs';
-import * as path from 'path';
+import { ConfigService } from '@nestjs/config';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('WechatService', () => {
-  const service = new WechatService();
-
-  const tmp = path.join(__dirname, 'wechat.test.json');
+  const service = new WechatService(new ConfigService({ wechat: { appid: 'appid', secret: 'secret' } } as any));
 
   beforeEach(() => {
     mockedAxios.get.mockReset();
-    fs.writeFileSync(tmp, JSON.stringify({ wechat: { appid: 'appid', secret: 'secret' } }));
-    process.env.APP_CONFIG_PATH = tmp;
-  });
-
-  afterEach(() => {
-    if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
-    delete process.env.APP_CONFIG_PATH;
   });
 
   it('throws when code invalid', async () => {

--- a/backend/pet-feeder-backend/src/domains/auth/wechat.service.ts
+++ b/backend/pet-feeder-backend/src/domains/auth/wechat.service.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 
 export interface WechatSession {
   openid: string;
+  unionid?: string;
   session_key: string;
 }
 
@@ -30,6 +31,10 @@ export class WechatService {
     if (!data.openid || !data.session_key) {
       throw new UnauthorizedException('Invalid wechat response');
     }
-    return { openid: data.openid, session_key: data.session_key };
+    return {
+      openid: data.openid,
+      unionid: data.unionid,
+      session_key: data.session_key,
+    };
   }
 }

--- a/backend/pet-feeder-backend/src/domains/orders/__tests__/payment.service.spec.ts
+++ b/backend/pet-feeder-backend/src/domains/orders/__tests__/payment.service.spec.ts
@@ -30,7 +30,7 @@ describe('OrdersService payment', () => {
     orderRepo.findOne = jest.fn().mockResolvedValue({ id: 1 });
     wxPay.createJsapiTransaction.mockResolvedValue({ prepay_id: 'p' });
 
-    const res = await service.createPrepay({ orderId: '1', openid: 'o' });
+    const res = await service.createPrepay({ orderId: '1', openId: 'o' });
     expect(wxPay.createJsapiTransaction).toBeCalledWith('o', 1, '1');
     expect(res).toEqual({ prepay_id: 'p' });
   });

--- a/backend/pet-feeder-backend/src/domains/orders/dto/pay-order.dto.ts
+++ b/backend/pet-feeder-backend/src/domains/orders/dto/pay-order.dto.ts
@@ -6,7 +6,7 @@ export class PayOrderDto {
   @IsString()
   orderId: string;
 
-  /** 用户的 openid，用于微信支付 */
+  /** 用户的 openId，用于微信支付 */
   @IsString()
-  openid: string;
+  openId: string;
 }

--- a/backend/pet-feeder-backend/src/domains/orders/orders.service.ts
+++ b/backend/pet-feeder-backend/src/domains/orders/orders.service.ts
@@ -104,14 +104,14 @@ export class OrdersService {
 
   /**
    * 创建微信支付预订单
-   * @param dto 订单编号及用户openid
+   * @param dto 订单编号及用户openId
    */
   async createPrepay(dto: PayOrderDto) {
     const order = await this.ordersRepository.findOne({
       where: { id: parseInt(dto.orderId, 10) },
     });
     if (!order) throw new BusinessException(2002, 'ORDER_NOT_FOUND', HttpStatus.NOT_FOUND);
-    return this.wxPay.createJsapiTransaction(dto.openid, 1, dto.orderId);
+    return this.wxPay.createJsapiTransaction(dto.openId, 1, dto.orderId);
   }
 
   /**

--- a/backend/pet-feeder-backend/src/domains/orders/wx-pay.service.ts
+++ b/backend/pet-feeder-backend/src/domains/orders/wx-pay.service.ts
@@ -25,12 +25,12 @@ export class WxPayService {
 
   /**
    * 创建 JSAPI 支付交易
-   * @param openid 用户 openid
+   * @param openId 用户 openid
    * @param amount 金额，单位分
    * @param outTradeNo 订单号
    */
   async createJsapiTransaction(
-    openid: string,
+    openId: string,
     amount: number,
     outTradeNo: string,
   ): Promise<JsapiPayParams> {

--- a/backend/pet-feeder-backend/src/domains/tracking/wx-template.service.ts
+++ b/backend/pet-feeder-backend/src/domains/tracking/wx-template.service.ts
@@ -4,7 +4,7 @@ import { Injectable, Logger } from '@nestjs/common';
 export class WxTemplateService {
   private readonly logger = new Logger('WxTemplate');
 
-  async send(openid: string, templateId: string, data: any, page = '') {
+  async send(openId: string, templateId: string, data: any, page = '') {
     // Placeholder implementation using fetch
     const accessToken = 'ACCESS_TOKEN';
     try {
@@ -13,7 +13,7 @@ export class WxTemplateService {
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ touser: openid, template_id: templateId, data, page }),
+          body: JSON.stringify({ touser: openId, template_id: templateId, data, page }),
         },
       );
     } catch (e) {

--- a/backend/pet-feeder-backend/src/domains/users/dto/create-user.dto.ts
+++ b/backend/pet-feeder-backend/src/domains/users/dto/create-user.dto.ts
@@ -4,7 +4,12 @@ import { IsOptional, IsString, Matches } from 'class-validator';
 export class CreateUserDto {
   /** 微信 openid */
   @IsString()
-  openid: string;
+  openId: string;
+
+  /** 微信 unionid，可为空 */
+  @IsOptional()
+  @IsString()
+  unionId?: string;
 
   /** 用户昵称 */
   @IsString()

--- a/backend/pet-feeder-backend/src/domains/users/entities/user.entity.ts
+++ b/backend/pet-feeder-backend/src/domains/users/entities/user.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Pet } from '../../pets/entities/pet.entity';
 import { Order } from '../../orders/entities/order.entity';
 
@@ -11,7 +18,11 @@ export class User {
 
   /** 微信 openid 唯一 */
   @Column({ unique: true })
-  openid: string;
+  openId: string;
+
+  /** 微信 unionid，可为空全局唯一 */
+  @Column({ unique: true, nullable: true })
+  unionId?: string;
 
   /** 昵称 */
   @Column({ length: 100 })
@@ -32,6 +43,14 @@ export class User {
   /** 手机号 */
   @Column({ length: 20, nullable: true })
   phone?: string;
+
+  /** 创建时间 */
+  @CreateDateColumn()
+  createdAt: Date;
+
+  /** 更新时间 */
+  @UpdateDateColumn()
+  updatedAt: Date;
 
   /** 用户拥有的宠物 */
   @OneToMany(() => Pet, (pet) => pet.user)

--- a/backend/pet-feeder-backend/src/domains/users/users.controller.ts
+++ b/backend/pet-feeder-backend/src/domains/users/users.controller.ts
@@ -1,9 +1,13 @@
 // 👉 模块：用户管理接口
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Req, Put, UseGuards } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
 
+@UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('users')
 /**
  * 用户接口控制器
@@ -18,8 +22,9 @@ export class UsersController {
   }
 
   @Get()
+  @Roles('admin')
   /** 获取用户列表 */
-  findAll() {
+  getAllUsers() {
     return this.usersService.findAll();
   }
 
@@ -27,6 +32,20 @@ export class UsersController {
   /** 根据ID获取用户 */
   findOne(@Param('id') id: string) {
     return this.usersService.findOne(+id);
+  }
+
+  @Get('profile')
+  @Roles('user')
+  getProfile(@Req() req) {
+    const userId = req.user.userId;
+    return this.usersService.findOne(userId);
+  }
+
+  @Put('profile')
+  @Roles('user')
+  updateProfile(@Req() req, @Body() updateUserDto: UpdateUserDto) {
+    const userId = req.user.userId;
+    return this.usersService.update(userId, updateUserDto);
   }
 
   @Patch(':id')

--- a/backend/pet-feeder-backend/src/domains/users/users.service.ts
+++ b/backend/pet-feeder-backend/src/domains/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -17,7 +17,7 @@ export class UsersService {
   ) {}
 
   /** 新建用户 */
-  create(createUserDto: CreateUserDto) {
+  create(createUserDto: CreateUserDto): Promise<User> {
     const user = this.usersRepository.create(createUserDto);
     return this.usersRepository.save(user);
   }
@@ -32,14 +32,24 @@ export class UsersService {
     return this.usersRepository.findOne({ where: { id } });
   }
 
-  /** 根据 openid 查询用户 */
-  findByOpenid(openid: string) {
-    return this.usersRepository.findOne({ where: { openid } });
+  /** 根据 openId 查询用户 */
+  findByOpenId(openId: string): Promise<User | undefined> {
+    return this.usersRepository.findOne({ where: { openId } });
   }
 
-  /** 更新用户 */
-  update(id: number, updateUserDto: UpdateUserDto) {
-    return this.usersRepository.update(id, updateUserDto);
+  /** 根据 unionId 查询用户 */
+  findByUnionId(unionId: string): Promise<User | undefined> {
+    return this.usersRepository.findOne({ where: { unionId } });
+  }
+
+  /** 更新用户信息 */
+  async update(id: number, updateUserDto: UpdateUserDto): Promise<User> {
+    const user = await this.usersRepository.findOne({ where: { id } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    Object.assign(user, updateUserDto);
+    return this.usersRepository.save(user);
   }
 
   /** 删除用户 */

--- a/backend/pet-feeder-backend/test/admin-workflow.e2e-spec.ts
+++ b/backend/pet-feeder-backend/test/admin-workflow.e2e-spec.ts
@@ -146,7 +146,7 @@ describe('Admin & order workflow (e2e)', () => {
     expect(profileRes.body.data.username).toBe('operator');
     const userRes = await request(server)
       .post('/users')
-      .send({ openid: 'f1', nickname: 'F1' });
+      .send({ openId: 'f1', nickname: 'F1' });
     const userId = userRes.body.data.id;
     const feederRes = await request(server)
       .post('/feeders')
@@ -191,7 +191,7 @@ describe('Admin & order workflow (e2e)', () => {
       await request(server).post('/admin/login').send({ username: 'op1', password: 'pwd' })
     ).body.data.access_token;
 
-    const uRes = await request(server).post('/users').send({ openid: 'del1', nickname: 'd' });
+    const uRes = await request(server).post('/users').send({ openId: 'del1', nickname: 'd' });
     const feeder = await request(server)
       .post('/feeders')
       .send({ userId: uRes.body.data.id, name: 'D', phone: '13000000002', idCard: '110101199001011111' });
@@ -214,7 +214,7 @@ describe('Admin & order workflow (e2e)', () => {
   it('manages orders with status updates and pagination', async () => {
     const userRes = await request(server)
       .post('/users')
-      .send({ openid: 'o1', nickname: 'OrderUser' });
+      .send({ openId: 'o1', nickname: 'OrderUser' });
     const userId = userRes.body.data.id;
     const userToken = await jwt.signAsync({ sub: userId, role: 'user' });
     const petRes = await request(server)

--- a/backend/pet-feeder-backend/test/feeder-workflow.e2e-spec.ts
+++ b/backend/pet-feeder-backend/test/feeder-workflow.e2e-spec.ts
@@ -88,7 +88,7 @@ describe('Feeder workflow (e2e)', () => {
     jest.spyOn(wxService, 'send').mockResolvedValue(undefined);
     const loginRes = await request(server)
       .post('/auth/wx-login')
-      .send({ openid: 'user', nickname: 'user', avatar: 'a.jpg' });
+      .send({ openId: 'user', nickname: 'user', avatar: 'a.jpg' });
     token = loginRes.body.data.access_token;
   });
 
@@ -99,7 +99,7 @@ describe('Feeder workflow (e2e)', () => {
   it('should register, approve and finish service with images', async () => {
     const userRes = await request(server)
       .post('/users')
-      .send({ openid: 'feeder1', nickname: 'feeder1' });
+      .send({ openId: 'feeder1', nickname: 'feeder1' });
     const feederRes = await request(server).post('/feeders').send({
       userId: userRes.body.data.id,
       name: 'Feeder 1',
@@ -112,7 +112,7 @@ describe('Feeder workflow (e2e)', () => {
 
     const ownerRes = await request(server)
       .post('/users')
-      .send({ openid: 'owner', nickname: 'owner' });
+      .send({ openId: 'owner', nickname: 'owner' });
     const petRes = await request(server)
       .post('/pets')
       .set('Authorization', `Bearer ${token}`)
@@ -152,7 +152,7 @@ describe('Feeder workflow (e2e)', () => {
   it('should transition status correctly', async () => {
     const uRes = await request(server)
       .post('/users')
-      .send({ openid: 'feeder2', nickname: 'feeder2' });
+      .send({ openId: 'feeder2', nickname: 'feeder2' });
     const fRes = await request(server).post('/feeders').send({
       userId: uRes.body.data.id,
       name: 'Feeder 2',
@@ -165,7 +165,7 @@ describe('Feeder workflow (e2e)', () => {
 
     const ownerRes = await request(server)
       .post('/users')
-      .send({ openid: 'owner2', nickname: 'owner2' });
+      .send({ openId: 'owner2', nickname: 'owner2' });
     const petRes = await request(server)
       .post('/pets')
       .set('Authorization', `Bearer ${token}`)
@@ -211,7 +211,7 @@ describe('Feeder workflow (e2e)', () => {
   it('should allow only one feeder to accept an order', async () => {
     const owner = await request(server)
       .post('/users')
-      .send({ openid: 'owner3', nickname: 'owner3' });
+      .send({ openId: 'owner3', nickname: 'owner3' });
     const pet = await request(server)
       .post('/pets')
       .set('Authorization', `Bearer ${token}`)
@@ -230,13 +230,13 @@ describe('Feeder workflow (e2e)', () => {
 
     const fu1 = await request(server)
       .post('/users')
-      .send({ openid: 'feeder3', nickname: 'f3' });
+      .send({ openId: 'feeder3', nickname: 'f3' });
     const feeder1 = await request(server)
       .post('/feeders')
       .send({ userId: fu1.body.data.id, name: 'f3', phone: '1', idCard: '1' });
     const fu2 = await request(server)
       .post('/users')
-      .send({ openid: 'feeder4', nickname: 'f4' });
+      .send({ openId: 'feeder4', nickname: 'f4' });
     const feeder2 = await request(server)
       .post('/feeders')
       .send({ userId: fu2.body.data.id, name: 'f4', phone: '1', idCard: '2' });
@@ -257,7 +257,7 @@ describe('Feeder workflow (e2e)', () => {
   it('should validate sign-in distance', async () => {
     const uRes = await request(server)
       .post('/users')
-      .send({ openid: 'feeder5', nickname: 'f5' });
+      .send({ openId: 'feeder5', nickname: 'f5' });
     const fRes = await request(server)
       .post('/feeders')
       .send({ userId: uRes.body.data.id, name: 'f5', phone: '1', idCard: '3' });
@@ -266,7 +266,7 @@ describe('Feeder workflow (e2e)', () => {
 
     const oRes = await request(server)
       .post('/users')
-      .send({ openid: 'owner4', nickname: 'o4' });
+      .send({ openId: 'owner4', nickname: 'o4' });
     const pRes = await request(server)
       .post('/pets')
       .set('Authorization', `Bearer ${token}`)
@@ -306,7 +306,7 @@ describe('Feeder workflow (e2e)', () => {
   it('should reject order for blacklisted feeder', async () => {
     const uRes = await request(server)
       .post('/users')
-      .send({ openid: 'feeder6', nickname: 'f6' });
+      .send({ openId: 'feeder6', nickname: 'f6' });
     const fRes = await request(server)
       .post('/feeders')
       .send({ userId: uRes.body.data.id, name: 'f6', phone: '1', idCard: '4' });
@@ -318,7 +318,7 @@ describe('Feeder workflow (e2e)', () => {
 
     const owner = await request(server)
       .post('/users')
-      .send({ openid: 'owner5', nickname: 'o5' });
+      .send({ openId: 'owner5', nickname: 'o5' });
     const pet = await request(server)
       .post('/pets')
       .set('Authorization', `Bearer ${token}`)

--- a/backend/pet-feeder-backend/test/user-flow.e2e-spec.ts
+++ b/backend/pet-feeder-backend/test/user-flow.e2e-spec.ts
@@ -112,8 +112,8 @@ describe('User core flow (e2e)', () => {
     // login to obtain JWT
     const loginRes = await request(server)
       .post('/auth/wx-login')
-      .send({ openid: 'user_openid', nickname: 'TestUser', avatar: 'a.jpg' });
-    token = loginRes.body.data.access_token;
+      .send({ openId: 'user_openid', nickname: 'TestUser', avatar: 'a.jpg' });
+    token = loginRes.body.data.token;
 
     const profileRes = await request(server)
       .get('/auth/profile')
@@ -138,7 +138,7 @@ describe('User core flow (e2e)', () => {
     // ensure there is an available feeder
     const fUserRes = await request(server)
       .post('/users')
-      .send({ openid: 'feeder_avail', nickname: 'fa' });
+      .send({ openId: 'feeder_avail', nickname: 'fa' });
     const feeder0 = await request(server).post('/feeders').send({
       userId: fUserRes.body.data.id,
       name: 'Available',
@@ -175,7 +175,7 @@ describe('User core flow (e2e)', () => {
     // create feeder and service order
     const uRes = await request(server)
       .post('/users')
-      .send({ openid: 'feeder_openid', nickname: 'Feeder' });
+      .send({ openId: 'feeder_openid', nickname: 'Feeder' });
     const feederRes = await request(server).post('/feeders').send({
       userId: uRes.body.data.id,
       name: 'Feeder',


### PR DESCRIPTION
## Summary
- add unionId and timestamps to `User` entity
- implement WeChat login DTO and service session handling
- expose `/auth/wx-login` using new `WechatService`
- add `loginWithWechat` in `AuthService`
- guard user routes and provide profile endpoints
- extend `UsersService` with openId/unionId lookup and safer update
- unify JWT strategy payload
- adjust tests for new login flow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a6092f3083208a7814a5a331b706